### PR TITLE
[fix] Delete duplicated index file in `components/atoms/`

### DIFF
--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,1 +1,2 @@
-export * from './Logo'
+export * from "./Logo";
+export * from "./Button";

--- a/src/components/atoms/index.tsx
+++ b/src/components/atoms/index.tsx
@@ -1,1 +1,0 @@
-export * from './Button'


### PR DESCRIPTION
`src/components/atoms/` 直下の index ファイルが2つあり、エラーが発生していたので1つにまとめました。

## 問題
`src/components/pages/PageTop/index.tsx` にて、 Button コンポーネントの import でエラーが発生している。

```zsh
❯ yarn build
yarn run v1.22.18
$ next build && next export
info  - SWC minify release candidate enabled. https://nextjs.link/swcmin
info  - Linting and checking validity of types ..Failed to compile.

./src/components/pages/PageTop/index.tsx:3:10
Type error: Module '"src/components/atoms"' has no exported member 'Button'.

  1 | import { Box, Typography } from '@mui/material'
  2 | import type { NextPage } from 'next'
> 3 | import { Button } from 'src/components/atoms'
    |          ^
  4 | import { Layout } from 'src/components/commons'
  5 | import { useTranslation } from 'react-i18next'
  6 | import { useRouter } from 'next/router'

> Build error occurred
Error: Call retries were exceeded
    at ChildProcessWorker.initialize (/Users/kiyokawa.taiga/github.com/GoCon/2023/node_modules/next/dist/compiled/jest-worker/index.js:1:11661)
    at ChildProcessWorker._onExit (/Users/kiyokawa.taiga/github.com/GoCon/2023/node_modules/next/dist/compiled/jest-worker/index.js:1:12599)
    at ChildProcess.emit (node:events:390:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12) {
  type: 'WorkerError'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
``` 

### `yarn dev` を実行して localhost:3000 にアクセスした時の画面表示
![image](https://user-images.githubusercontent.com/40013676/193037466-71c02fe0-5d2f-4af0-8381-2a0d1664c501.png)


## やったこと
- `src/components/atoms/index.tsx` を削除
- `src/components/atoms/index.ts` に `export * from "./Button";` を追加
- `yarn build` と `yarn dev` を実行して動作確認