### PR TITLE
vs codeのgit機能が使えなくなっていたのでnpxのパスを通した

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin/"
 npx lint-staged


### PR DESCRIPTION
# やったこと
* VS Codeで`git commit` しようとするとエラーが発生していたので、スクリプトを修正した
  * ref: https://github.com/typicode/husky/issues/912#issuecomment-887840695