### PR TITLE
fix: footer

### DIFF
--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -184,10 +184,17 @@ export const Footer = () => {
           sx={
             isTabletOrOver
               ? {
+                  fontFamily: 'Poppins',
                   position: 'absolute',
-                  right: '0px'
+                  right: '0px',
+                  color: Colors.text.primary,
+                  fontSize: '12px'
                 }
-              : {}
+              : {
+                  fontFamily: 'Poppins',
+                  color: Colors.text.primary,
+                  fontSize: '10px'
+                }
           }
         >
           <Typography
@@ -199,19 +206,19 @@ export const Footer = () => {
               textAlign: isTabletOrOver ? 'right' : 'left'
             }}
           >
-            <Box>Go Conference</Box>
-            <Trans t={t} i18nKey="gopher_copyright">
-              the_gopher_was_desigined_by
-              <Link href="http://reneefrench.blogspot.com/" target="_blank">
-                author
-              </Link>
-              illustrations_by
-              <Link href="https://twitter.com/tottie_designer" target="_blank">
-                author
-              </Link>
-              .
-            </Trans>
+            Go Conference
           </Typography>
+          <Trans t={t} i18nKey="gopher_copyright" fontSize={isTabletOrOver ? '12px' : '10px'}>
+            the_gopher_was_desigined_by
+            <Link href="http://reneefrench.blogspot.com/" target="_blank">
+              author
+            </Link>
+            illustrations_by
+            <Link href="https://twitter.com/tottie_designer" target="_blank">
+              author
+            </Link>
+            .
+          </Trans>
         </Box>
       </FooterBottom>
     </Box>


### PR DESCRIPTION
レンダリングされるHTMLの構造が、pタグの中にaタグが存在する書き方になっており、開発環境では警告が表示されていた

![image](https://user-images.githubusercontent.com/49754654/201461924-6b458623-637c-4c74-becf-7e50fb28901a.png)

![image](https://user-images.githubusercontent.com/49754654/201462006-1b80028f-e83b-4576-9178-db50b21493db.png)
