### PR TITLE
[feat][refactor] Make overall to be responsive

### DIFF
--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -21,7 +21,7 @@ export const Button = ({ text, width = '370px', onClick }: ButtonProps) => {
       }}
       onClick={onClick}
     >
-      <Typography variant="body1" sx={{ color: Colors.button.primary.text }}>
+      <Typography fontSize="16px" sx={{ color: Colors.button.primary.text }}>
         {text}
       </Typography>
     </ButtonBase>

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -8,16 +8,15 @@ type ButtonProps = {
   onClick?: () => void
 }
 
-export const Button = ({ text, width = '370px', onClick }: ButtonProps) => {
+export const Button = ({ text, onClick }: ButtonProps) => {
   return (
     <ButtonBase
       sx={{
         hight: '54px',
-        width,
+        minWidth: { md: '360px', xs: '280px' },
         borderRadius: '100px',
-        background: Colors.button.primary.enabled,
-        px: '24px',
-        py: '16px'
+        p: '16px 24px',
+        backgroundColor: Colors.button.primary.enabled
       }}
       onClick={onClick}
     >

--- a/src/components/molecules/SponsorsCard/index.tsx
+++ b/src/components/molecules/SponsorsCard/index.tsx
@@ -74,7 +74,7 @@ export const SponsorsCard: FC<Props> = ({ planType, logoImages }) => {
 
   return (
     <Box bgcolor={Colors.background.primary} maxWidth={'1024px'} width={'100%'} borderRadius={5} p={{ xs: 3, md: 5 }}>
-      <Typography variant="h3" align="center" mb={3} fontWeight={600} color={Colors.text.primary}>
+      <Typography variant="h3" align="center" mb={3}>
         {heading}
       </Typography>
       <Grid container spacing={{ xs: 1, md: 3 }} mx={'auto'} width={gridWidth} columns={columns}>

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -184,15 +184,11 @@ export const Footer = () => {
           sx={
             isTabletOrOver
               ? {
-                  fontFamily: 'Poppins',
                   position: 'absolute',
                   right: '0px',
-                  color: Colors.text.primary,
                   fontSize: '12px'
                 }
               : {
-                  fontFamily: 'Poppins',
-                  color: Colors.text.primary,
                   fontSize: '10px'
                 }
           }
@@ -208,17 +204,19 @@ export const Footer = () => {
           >
             Go Conference
           </Typography>
-          <Trans t={t} i18nKey="gopher_copyright" fontSize={isTabletOrOver ? '12px' : '10px'}>
-            the_gopher_was_desigined_by
-            <Link href="http://reneefrench.blogspot.com/" target="_blank">
-              author
-            </Link>
-            illustrations_by
-            <Link href="https://twitter.com/tottie_designer" target="_blank">
-              author
-            </Link>
-            .
-          </Trans>
+          <Typography fontSize={isTabletOrOver ? '12px' : '10px'}>
+            <Trans t={t} i18nKey="gopher_copyright">
+              the_gopher_was_desigined_by
+              <Link href="http://reneefrench.blogspot.com/" target="_blank">
+                author
+              </Link>
+              illustrations_by
+              <Link href="https://twitter.com/tottie_designer" target="_blank">
+                author
+              </Link>
+              .
+            </Trans>
+          </Typography>
         </Box>
       </FooterBottom>
     </Box>

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -46,7 +46,7 @@ export const Header = () => {
           </Box>
         )}
         <Box sx={{ margin: '0 24px 0 auto' }}>
-          <Typography onClick={handleChangeLanguage} sx={{ color: fontColor, fontFamily: 'Poppins' }}>
+          <Typography onClick={handleChangeLanguage} sx={{ color: fontColor }}>
             {t('change_language')}
           </Typography>
         </Box>

--- a/src/components/organisms/SpeakersSection/index.tsx
+++ b/src/components/organisms/SpeakersSection/index.tsx
@@ -14,9 +14,11 @@ import {
   GopherTrumpeter
 } from 'src/images/gopher'
 import Image from 'next/image'
+import { useSize } from 'src/modules/hooks'
 
 export const SpeakersSection: FC = () => {
   const { t } = useTranslation()
+  const { isTabletOrOver } = useSize()
 
   return (
     <Box
@@ -25,30 +27,51 @@ export const SpeakersSection: FC = () => {
       flexDirection={'column'}
       alignItems={'center'}
       py={{ md: 10, xs: 4 }}
+      position="relative"
     >
       <Typography variant="h2">Wanted to Speakers!</Typography>
       <Box mb={1}>
         <Typography variant="body2">{t('application_started')}: 2022.12.01 Thu</Typography>
         <Typography variant="body2">{t('application_closed')}: 2023.01.31 Sat</Typography>
       </Box>
-      <Box display="grid" gridTemplateColumns="1fr 1fr 1fr" gap={2}>
-        <Box display="flex" alignItems="flex-end" justifyContent="flex-end" gap={0.5}>
-          <Image src={GopherConductor} alt="gopher conductor" />
-          <Image src={GopherDrummer} alt="gopher drummer" />
-          <Image src={GopherTrumpeter} alt="gopher trumpeter" />
-          <Image src={GopherPomPom} alt="gopher pom pom" />
-        </Box>
+      <Box display="grid" gridTemplateColumns={isTabletOrOver ? '1fr 1fr 1fr' : '1fr'} gap={2}>
+        {isTabletOrOver && (
+          <Box display="flex" alignItems="flex-end" justifyContent="flex-end" gap={0.5}>
+            <Image src={GopherConductor} alt="gopher conductor" />
+            <Image src={GopherDrummer} alt="gopher drummer" />
+            <Image src={GopherTrumpeter} alt="gopher trumpeter" />
+            <Image src={GopherPomPom} alt="gopher pom pom" />
+          </Box>
+        )}
         <Link href="https://sessionize.com/go-conference-2023-online/">
           <a target="_blank">
             <Button text={t('apply_for_speaker')} />
           </a>
         </Link>
-        <Box display="flex" alignItems="flex-end" gap={0.5}>
-          <Image src={GopherFlowerBlue} alt="gopher flower blue" />
-          <Image src={GopherFlowerPink} alt="gopher flower pink" />
-          <Image src={GopherPartyPopper} alt="gopher party popper" />
-        </Box>
+        {isTabletOrOver && (
+          <Box display="flex" alignItems="flex-end" gap={0.5}>
+            <Image src={GopherFlowerBlue} alt="gopher flower blue" />
+            <Image src={GopherFlowerPink} alt="gopher flower pink" />
+            <Image src={GopherPartyPopper} alt="gopher party popper" />
+          </Box>
+        )}
       </Box>
+      {!isTabletOrOver && (
+        <Box
+          sx={{
+            position: 'absolute',
+            zIndex: 0,
+            top: '56px',
+            right: 0,
+            display: 'flex',
+            alignItems: 'flex-end',
+            opacity: 0.7
+          }}
+        >
+          <Image src={GopherConductor} alt="gopher conductor" width="56px" objectFit="contain" />
+          <Image src={GopherDrummer} alt="gopher drummer" width="52px" objectFit="contain" />
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/components/organisms/SpeakersSection/index.tsx
+++ b/src/components/organisms/SpeakersSection/index.tsx
@@ -26,12 +26,10 @@ export const SpeakersSection: FC = () => {
       alignItems={'center'}
       py={{ md: 10, xs: 4 }}
     >
-      <Typography variant="h1" mb={5}>
-        Wanted to Speakers!
-      </Typography>
+      <Typography variant="h2">Wanted to Speakers!</Typography>
       <Box mb={1}>
-        <Typography>{t('application_started')}: 2022.12.01 Thu</Typography>
-        <Typography>{t('application_closed')}: 2023.01.31 Sat</Typography>
+        <Typography variant="body2">{t('application_started')}: 2022.12.01 Thu</Typography>
+        <Typography variant="body2">{t('application_closed')}: 2023.01.31 Sat</Typography>
       </Box>
       <Box display="grid" gridTemplateColumns="1fr 1fr 1fr" gap={2}>
         <Box display="flex" alignItems="flex-end" justifyContent="flex-end" gap={0.5}>

--- a/src/components/organisms/SponsorsSection/index.tsx
+++ b/src/components/organisms/SponsorsSection/index.tsx
@@ -18,11 +18,11 @@ export const SponsorsSection: FC = () => {
       px={{ xs: 2 }}
       py={{ md: 10, xs: 4 }}
     >
-      <Typography variant="h1" mb={5} textAlign={'center'}>
+      <Typography variant="h2" textAlign={'center'}>
         Sponsors
       </Typography>
       {/* TODO: This description will be changed as soon as the official wording is fixed. */}
-      <Typography variant="body1" mb={5} fontSize={{ md: '1.5rem', xs: '1rem' }}>
+      <Typography variant="body1" mb={{ md: 5, xs: 2 }}>
         {t('sponsors_description')}
       </Typography>
       {/* NOTE: Hide SponsorsCard until the top level sponsors has fixed.

--- a/src/components/organisms/TopDescription/index.tsx
+++ b/src/components/organisms/TopDescription/index.tsx
@@ -16,26 +16,12 @@ export const TopDescription = () => {
     >
       <Box maxWidth={'680px'} margin={'auto'}>
         <Box sx={{ textAlign: 'center' }}>
-          <Typography
-            variant="h2"
-            sx={{
-              color: Colors.text.white,
-              fontWeight: 500,
-              fontSize: isTabletOrOver ? '50px' : '24px',
-              padding: isTabletOrOver ? '40px' : '8px'
-            }}
-          >
+          <Typography variant="h2" sx={{ color: Colors.text.white }}>
             What is Go Conference?
           </Typography>
         </Box>
         <Box sx={{ textAlign: 'center', mb: isTabletOrOver ? '40px' : '16px' }}>
-          <Typography
-            variant="body1"
-            sx={{
-              color: Colors.text.white,
-              fontSize: isTabletOrOver ? '24px' : '16px'
-            }}
-          >
+          <Typography variant="body1" sx={{ color: Colors.text.white }}>
             {t('about')}
           </Typography>
         </Box>
@@ -50,7 +36,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 textAlign: 'right',
                 minWidth: isTabletOrOver ? '120px' : '100px',
                 marginLeft: isTabletOrOver ? '32px' : '0'
@@ -62,7 +47,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 marginLeft: '12px'
               }}
             >
@@ -79,7 +63,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 textAlign: 'right',
                 minWidth: isTabletOrOver ? '120px' : '100px',
                 marginLeft: isTabletOrOver ? '32px' : '0'
@@ -91,7 +74,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 marginLeft: '12px'
               }}
             >
@@ -108,7 +90,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 textAlign: 'right',
                 minWidth: isTabletOrOver ? '120px' : '100px',
                 marginLeft: isTabletOrOver ? '32px' : '0'
@@ -120,7 +101,6 @@ export const TopDescription = () => {
               variant="body2"
               sx={{
                 color: Colors.text.white,
-                fontSize: isTabletOrOver ? '18px' : '14px',
                 marginLeft: '12px'
               }}
             >

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -29,4 +29,4 @@ export const Colors = {
       highlight: '#E5E5E5'
     }
   }
-}
+} as const

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,8 +2,8 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif, Poppins, Montserrat;
+  font-family: 'Poppins', 'Montserrat', -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
 
 a {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,12 +1,49 @@
-import { createTheme } from '@mui/material/styles'
+import { createTheme, ThemeOptions } from '@mui/material/styles'
+import { Colors } from './color'
 
-export const theme = createTheme({
+const defaultTheme = createTheme()
+
+const { breakpoints } = defaultTheme
+
+export const theme: ThemeOptions = {
+  ...defaultTheme,
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        color: Colors.text.primary
+      }
+    }
+  },
   typography: {
-    allVariants: { fontFamily: 'Poppins' },
-    h1: { fontSize: 50 },
-    // TODO: Fix fontSize as follow Figma's one.
-    h2: { fontSize: 24 },
-    h3: { fontSize: 34 },
-    caption: { fontSize: 14 }
+    h2: {
+      fontSize: '50px',
+      fontWeight: 500,
+      marginBottom: '40px',
+      [breakpoints.down('sm')]: {
+        fontSize: '24px',
+        marginBottom: '16px'
+      }
+    },
+    h3: {
+      fontSize: '34px',
+      fontWeight: 600,
+      marginBottom: '24px',
+      [breakpoints.down('sm')]: {
+        fontSize: '20px',
+        marginBottom: '16px'
+      }
+    },
+    body1: {
+      fontSize: '24px',
+      [breakpoints.down('sm')]: {
+        fontSize: '16px'
+      }
+    },
+    body2: {
+      fontSize: '18px',
+      [breakpoints.down('sm')]: {
+        fontSize: '14px'
+      }
+    }
   }
-})
+}


### PR DESCRIPTION
## 概要
全体的にレスポンシブデザインに対応するように調整しました。 Footer のフォントサイズ周りが若干崩れてしまったのですが差分が大きくなりすぎそうなので一旦後回しにしています。

- [fix] Fix the order of `font-family`
- [refactor] Add responsive font sizes etc for variants of Typography
- [feat] Add responsive design for Speakers section
- [refactor] Adjust Button styles

## 保留したタスク
- Footer のリファクタリング
  - 個別で fontSize 指定している箇所が多かったので theme で管理したい
- Button の hover 時のスタイル
  - なんか sx でいい感じ当てられなかった...
- SpeakersSection のモバイル幅の時の Gopher さんが 320px くらい狭まると応募期間に被る
  - なんかいい感じにズラすか諦めるか
  - どこまで担保するかにもよるけど個人的には 375px 以下のレイアウト崩れはある程度許容しても良いと思う

## 様子

https://user-images.githubusercontent.com/40013676/204099473-2fccc92d-937c-41e9-ac22-04e29edf1df2.mov


