### PR TITLE
footerもvariant使うように修正

### DIFF
--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -44,13 +44,7 @@ export const Footer = () => {
               gap: '16px'
             }}
           >
-            <Typography
-              sx={{
-                fontWeight: 700,
-                fontSize: '16px',
-                color: Colors.text.default
-              }}
-            >
+            <Typography variant="h4" sx={{ color: Colors.text.default }}>
               About
             </Typography>
             <Box
@@ -61,26 +55,12 @@ export const Footer = () => {
               }}
             >
               <Link href="https://go.dev/conduct" target="_blank">
-                <Typography
-                  sx={{
-                    fontWeight: 400,
-                    fontSize: '14px',
-                    color: Colors.text.default,
-                    lineHeight: '140%'
-                  }}
-                >
+                <Typography variant="body2" sx={{ color: Colors.text.default }}>
                   Code of Conduct
                 </Typography>
               </Link>
               <Link href="mailto:info@gocon.jp" target="_blank">
-                <Typography
-                  sx={{
-                    fontWeight: 400,
-                    fontSize: '14px',
-                    color: Colors.text.default,
-                    lineHeight: '140%'
-                  }}
-                >
+                <Typography variant="body2" sx={{ color: Colors.text.default }}>
                   INFO@GOCON.JP
                 </Typography>
               </Link>
@@ -96,10 +76,8 @@ export const Footer = () => {
             }}
           >
             <Typography
+              variant="h4"
               sx={{
-                fontWeight: 700,
-                fontSize: '16px',
-                lineHeight: '140%',
                 color: Colors.text.default
               }}
             >
@@ -119,10 +97,9 @@ export const Footer = () => {
               ].map(([label, href]) => (
                 <Link href={href} key={label} target="_blank">
                   <Typography
+                    variant="body2"
                     key={label}
                     sx={{
-                      fontSize: '14px',
-                      lineHeight: '140%',
                       color: Colors.text.default
                     }}
                   >
@@ -169,10 +146,8 @@ export const Footer = () => {
           </Box>
           <Link href="https://twitter.com/hashtag/gocon" target="_blank">
             <Typography
+              variant="body2"
               sx={{
-                fontWeight: 400,
-                fontSize: '16px',
-                lineHeight: '140%',
                 color: Colors.text.secondary_default
               }}
             >

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -179,7 +179,7 @@ export const Footer = () => {
           >
             Go Conference
           </Typography>
-          <Typography variant="caption" fontSize={isTabletOrOver ? '12px' : '10px'}>
+          <Typography variant="caption">
             <Trans t={t} i18nKey="gopher_copyright">
               the_gopher_was_desigined_by
               <Link href="http://reneefrench.blogspot.com/" target="_blank">

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -179,7 +179,7 @@ export const Footer = () => {
           >
             Go Conference
           </Typography>
-          <Typography fontSize={isTabletOrOver ? '12px' : '10px'}>
+          <Typography variant="caption" fontSize={isTabletOrOver ? '12px' : '10px'}>
             <Trans t={t} i18nKey="gopher_copyright">
               the_gopher_was_desigined_by
               <Link href="http://reneefrench.blogspot.com/" target="_blank">

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -51,6 +51,12 @@ export const theme: ThemeOptions = {
       [breakpoints.down('sm')]: {
         fontSize: '14px'
       }
+    },
+    caption: {
+      fontSize: '12px',
+      [breakpoints.down('sm')]: {
+        fontSize: '10px'
+      }
     }
   }
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -33,6 +33,13 @@ export const theme: ThemeOptions = {
         marginBottom: '16px'
       }
     },
+    h4: {
+      fontSize: '20px',
+      fontWeight: 700,
+      [breakpoints.down('sm')]: {
+        fontSize: '16px'
+      }
+    },
     body1: {
       fontSize: '24px',
       [breakpoints.down('sm')]: {


### PR DESCRIPTION
# やったこと
* footerもvariantを見るように修正
  * 太いところはh4追加で対応
  * なかはbody2で対応
# やってないこと
* flexの整理
* `Gopher の原著作者~`の部分は大きすぎると不自然なのと、フォントサイズの制御をする必要がないと判断したのでそのままにしています
# その他
* 下のやつに比べて少し大きめになっているので、`subtitle`とかを使って制御した方が良い？

## before
<img width="667" alt="スクリーンショット 2022-11-27 13 53 10" src="https://user-images.githubusercontent.com/51983447/204119971-b3b310ab-d57f-4b60-a083-5b35a872708f.png">
## after
<img width="736" alt="スクリーンショット 2022-11-27 13 53 16" src="https://user-images.githubusercontent.com/51983447/204119972-58dfa5bc-8d88-483f-ae41-a10e5215d9c5.png">
