### PR TITLE
[fix] Add `overflow: hidden` to prevent collapsing layout cause of overflowing confetti from viewport

### DIFF
--- a/src/components/organisms/MainVisual/index.tsx
+++ b/src/components/organisms/MainVisual/index.tsx
@@ -53,7 +53,7 @@ export const MainVisual = () => {
   )
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box sx={{ width: '100%', overflow: 'hidden' }}>
       <Box
         sx={{
           position: 'relative',


### PR DESCRIPTION
## 概要
モバイルで確認したら紙吹雪がはみ出た時に盛大にレイアウトが崩れてたので `overflow: hidden` で対処しました。多分これでなおるはず。