### PR TITLE
[chore] Change link of the button in SponsorsSection to PDF for details of sponsorship plans

### DIFF
--- a/src/components/organisms/SponsorsSection/index.tsx
+++ b/src/components/organisms/SponsorsSection/index.tsx
@@ -32,7 +32,7 @@ export const SponsorsSection: FC = () => {
         <SponsorsCard planType="silver" logoImages={[]}/>
         <SponsorsCard planType="bronze" logoImages={[]}/>
       </Box> */}
-      <Link href="https://forms.gle/nbTxbQ6Fe4D4uY9B7">
+      <Link href="https://drive.google.com/file/d/1wwFeJk0rT0SydwDi2wx4wVVAD6psDUrL/view?usp=share_link">
         <a target="_blank">
           <Button text={t('consider_a_sponsor')} />
         </a>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,7 +4,7 @@
   "apply_for_speaker": "Apply for speaker",
   "application_started": "Application started",
   "application_closed": "Application closed",
-  "consider_a_sponsor": "Consider a sponsor",
+  "consider_a_sponsor": "Consider sponsoring",
   "about": "Go Conference is a conference for Go programming language users. It's the 10th anniversary!",
   "session": "session",
   "session_num": "30 or more sessions(Open call for paper at 2022/12)",


### PR DESCRIPTION
「スポンサーを検討する」ボタンのリンクをPDFへのリンクに変更しました。
ついでに英語のラベル「Consider a sponsor」を「Consider sponsoring」に変更しました。


https://user-images.githubusercontent.com/40013676/204576690-3a321cef-6fcf-4083-a6b9-c7a0a7a3cfad.mov


