### PR TITLE
[fix] Fix English sentences of Speakers section

### DIFF
--- a/src/components/organisms/SpeakersSection/index.tsx
+++ b/src/components/organisms/SpeakersSection/index.tsx
@@ -36,7 +36,7 @@ export const SpeakersSection: FC = () => {
       py={{ md: 10, xs: 4 }}
       position="relative"
     >
-      <Typography variant="h2">Wanted to Speakers!</Typography>
+      <Typography variant="h2">Call for Speakers!</Typography>
       <Box mb={1}>
         <Typography variant="body2">{t('application_started')}: 2022.12.01 Thu</Typography>
         <Typography variant="body2">{t('application_closed')}: 2023.01.31 Sat</Typography>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,7 +1,7 @@
 {
   "change_language": "日本語",
   "gopher_copyright": "The Go gopher was designed by <1>Renée French</1>. Illustrations by <3>tottie</3>.",
-  "apply_for_speaker": "Apply for speaker",
+  "apply_for_speaker": "Call for Speakers",
   "application_started": "Application started",
   "application_closed": "Application closed",
   "consider_a_sponsor": "Consider sponsoring",


### PR DESCRIPTION
(軽微なのでセルフマージします)

スピーカー募集セクションの英語を [Slack でご提案いただいた形](https://goconjp.slack.com/archives/C042B8LHA4R/p1669805616372079?thread_ts=1669600500.870169&cid=C042B8LHA4R) に修正しました。


![image](https://user-images.githubusercontent.com/40013676/204780234-f0cad225-8f5e-4c3d-aba7-16bcc1654d25.png)
