### PR TITLE
chore: Remove CommunityBoothSection from PageTop

### DIFF
--- a/src/components/pages/PageTop/index.tsx
+++ b/src/components/pages/PageTop/index.tsx
@@ -16,7 +16,6 @@ export const PageTop: NextPage = () => {
       <MainVisual />
       <TopDescription />
       <SponsorsSection />
-      <CommunityBoothSection />
     </Layout>
   )
 }


### PR DESCRIPTION
## 概要
コミュニティブースの募集は2月で既に締め切っていたのでトップページからリンクを削除する。

## 変更
PageTop コンポーネントから CommunityBoothSection を削除しました。コンポーネント自体は SpeakersSection と同様にそのまま残っています。

## 備考
![image](https://user-images.githubusercontent.com/40013676/229132248-4480b437-4ccd-4bf5-98f8-820742119627.png)

