### PR TITLE
Proposal feat: hide home label from header

### DIFF
--- a/src/components/molecules/HeaderMenu/index.tsx
+++ b/src/components/molecules/HeaderMenu/index.tsx
@@ -17,6 +17,8 @@ export const HeaderMenu = ({ menuList, itemColor, itemBehaviorStyles }: HeaderMe
     <Box sx={{ display: 'flex', gap: '8px', margin: '0 24px 0 auto' }}>
       {menuList.map((list, i) => {
         return list.href ? (
+          // TODO(maito1201): Enable this conditional branch when screen transition is implemented.
+          /* 
           list.href === '/' ? (
             <Link href={list.href} key={i}>
               <a>
@@ -33,21 +35,22 @@ export const HeaderMenu = ({ menuList, itemColor, itemBehaviorStyles }: HeaderMe
               </a>
             </Link>
           ) : (
-            // TODO(taigakiyokawa): Revert using `next/link` when pages have implemented.
-            <a href={list.href} target="_blank" rel="noreferrer" key={i}>
-              <Typography
-                sx={{
-                  borderBottom: router.pathname === list.href ? '3px solid' : '',
-                  color: itemColor.default,
-                  p: '4px 8px',
-                  ...itemBehaviorStyles
-                }}
-              >
-                {list.label}
-              </Typography>
-            </a>
-          )
+          */
+          // TODO(taigakiyokawa): Revert using `next/link` when pages have implemented.
+          <a href={list.href} target="_blank" rel="noreferrer" key={i}>
+            <Typography
+              sx={{
+                borderBottom: router.pathname === list.href ? '3px solid' : '',
+                color: itemColor.default,
+                p: '4px 8px',
+                ...itemBehaviorStyles
+              }}
+            >
+              {list.label}
+            </Typography>
+          </a>
         ) : (
+          // )
           <Typography
             onClick={list.onClick}
             sx={{
@@ -55,6 +58,7 @@ export const HeaderMenu = ({ menuList, itemColor, itemBehaviorStyles }: HeaderMe
               p: '4px 8px',
               ...itemBehaviorStyles
             }}
+            key={i}
           >
             {list.label}
           </Typography>

--- a/src/components/molecules/HeaderMenu/index.tsx
+++ b/src/components/molecules/HeaderMenu/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Typography, Box } from '@mui/material'
 import { useRouter } from 'next/router'
 import { HeaderItemColor, HeaderMenuItem, HeaderItemBehaviorStyles } from 'src/components/organisms/Header'
-import Link from 'next/link'
+// import Link from 'next/link'
 
 export interface HeaderMenuProps {
   menuList: HeaderMenuItem[]

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -54,7 +54,8 @@ export const Header = () => {
 
   const menuList: HeaderMenuItem[] = useMemo(() => {
     return [
-      { href: '/', label: 'Home' },
+      // TODO(maito1201): Display Home label when screen transition is implemented
+      // { href: '/', label: 'Home' },
       // TODO(taigakiyokawa): Revert to `/sessions` when the page has implemented.
       { href: 'https://sessionize.com/api/v2/jmtn42ls/view/Sessions', label: 'Sessions' },
       // TODO(taigakiyokawa): Revert to `/timetable` when the page has implemented.

--- a/src/components/pages/PageTop/index.tsx
+++ b/src/components/pages/PageTop/index.tsx
@@ -1,15 +1,15 @@
 import type { NextPage } from 'next'
 import { Layout } from 'src/components/commons'
 import { useTranslation } from 'react-i18next'
-import { useSessionize } from 'src/modules/sessionize/hooks'
+// import { useSessionize } from 'src/modules/sessionize/hooks'
 import { MainVisual, TopDescription, SponsorsSection, CommunityBoothSection } from 'src/components/organisms'
 
 export const PageTop: NextPage = () => {
   const { t } = useTranslation()
 
   // TODO(@maito1201): 取得したデータを基にセッションデータを表示する
-  const { data } = useSessionize()
-  console.log('session data', data)
+  // const { data } = useSessionize()
+  // console.log('session data', data)
 
   return (
     <Layout>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49754654/229265648-fa3246de-6e37-4fef-9638-98b2ce488ddb.png)

一旦この状態のものをmainブランチにマージする想定として、下記の変更を加えると良いかなと思いました

* Sessions, TimeTable, 言語切り替えのいずれも画面遷移を伴わないため、Homeの表示は不要かなと思います
* 余計な通信を行わないため、useSessionizeはコメントアウトします