### PR TITLE
chore: Close sponsors application

### DIFF
--- a/src/components/organisms/SponsorsSection/index.tsx
+++ b/src/components/organisms/SponsorsSection/index.tsx
@@ -1,7 +1,5 @@
 import type { FC } from 'react'
-import Link from 'next/link'
 import { Box, Typography } from '@mui/material'
-import { Button } from 'src/components/atoms'
 import { useTranslation } from 'react-i18next'
 import { Colors, confettiColors } from 'src/styles/color'
 import {
@@ -60,11 +58,6 @@ export const SponsorsSection: FC = () => {
             <Image src={GopherPomPom} alt="gopher pom pom" />
           </Box>
         )}
-        <Link href="https://drive.google.com/file/d/1wwFeJk0rT0SydwDi2wx4wVVAD6psDUrL/view?usp=share_link">
-          <a target="_blank">
-            <Button text={t('consider_a_sponsor')} />
-          </a>
-        </Link>
         {isTabletOrOver && (
           <Box display="flex" alignItems="flex-end" gap={0.5}>
             <Image src={GopherFlowerBlue} alt="gopher flower blue" />

--- a/src/components/organisms/SponsorsSection/index.tsx
+++ b/src/components/organisms/SponsorsSection/index.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 import { Box, Typography } from '@mui/material'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Colors, confettiColors } from 'src/styles/color'
 import {
   GopherConductor,
@@ -38,9 +38,11 @@ export const SponsorsSection: FC = () => {
       <Typography variant="h2" textAlign={'center'}>
         Sponsors
       </Typography>
-      {/* TODO: This description will be changed as soon as the official wording is fixed. */}
-      <Typography variant="body1" mb={{ md: 5, xs: 2 }}>
-        {t('sponsors_description')}
+      <Typography
+        variant="body1"
+        sx={{ mb: { md: 5, xs: 2 }, textAlign: 'center', wordBreak: 'keep-all', overflowWrap: 'break-word' }}
+      >
+        <Trans t={t} i18nKey="sponsors_application_closed" />
       </Typography>
       {/* NOTE: Hide SponsorsCard until the top level sponsors has fixed.
       <Box gap={3} mb={5} display={'flex'} flexDirection={'column'} width={'100%'} alignItems={'center'}>

--- a/src/components/organisms/SponsorsSection/index.tsx
+++ b/src/components/organisms/SponsorsSection/index.tsx
@@ -49,42 +49,22 @@ export const SponsorsSection: FC = () => {
         <SponsorsCard planType="silver" logoImages={[]}/>
         <SponsorsCard planType="bronze" logoImages={[]}/>
       </Box> */}
-      <Box display="grid" gridTemplateColumns={isTabletOrOver ? '1fr 1fr 1fr' : '1fr'} gap={2}>
+      <Box display="flex" alignItems="flex-end" justifyContent="flex-end" gap={0.5}>
+        <Image src={GopherConductor} alt="gopher conductor" />
+        <Image src={GopherDrummer} alt="gopher drummer" />
+        <Image src={GopherTrumpeter} alt="gopher trumpeter" />
+        <Image src={GopherPomPom} alt="gopher pom pom" />
+        <Image src={GopherFlowerBlue} alt="gopher flower blue" />
         {isTabletOrOver && (
-          <Box display="flex" alignItems="flex-end" justifyContent="flex-end" gap={0.5}>
-            <Image src={GopherConductor} alt="gopher conductor" />
-            <Image src={GopherDrummer} alt="gopher drummer" />
-            <Image src={GopherTrumpeter} alt="gopher trumpeter" />
-            <Image src={GopherPomPom} alt="gopher pom pom" />
-          </Box>
-        )}
-        {isTabletOrOver && (
-          <Box display="flex" alignItems="flex-end" gap={0.5}>
-            <Image src={GopherFlowerBlue} alt="gopher flower blue" />
+          <>
             <Image src={GopherFlowerPink} alt="gopher flower pink" />
             <Box onClick={reward} sx={{ '&:hover': { cursor: 'pointer' } }}>
               <span id="confettiGopherPopper" />
               <Image src={GopherPartyPopper} alt="gopher party popper" />
             </Box>
-          </Box>
+          </>
         )}
       </Box>
-      {!isTabletOrOver && (
-        <Box
-          sx={{
-            position: 'absolute',
-            zIndex: 0,
-            top: '56px',
-            right: 0,
-            display: 'flex',
-            alignItems: 'flex-end',
-            opacity: 0.7
-          }}
-        >
-          <Image src={GopherConductor} alt="gopher conductor" width="56px" objectFit="contain" />
-          <Image src={GopherDrummer} alt="gopher drummer" width="52px" objectFit="contain" />
-        </Box>
-      )}
     </Box>
   )
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -17,5 +17,6 @@
   "host": "organizer",
   "gophers_japan": "Institute Gophers Japan",
   "act_on_specified_commercial_transactions": "Act on Specified Commercial Transactions",
-  "sponsors_description": "We are looking for sponsors!"
+  "sponsors_description": "We are looking for sponsors!",
+  "sponsors_application_closed": "Sponsors application has been closed. We will reflect the information on our website in due course."
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -17,5 +17,6 @@
   "host": "主催",
   "gophers_japan": "一般社団法人Gophers Japan",
   "act_on_specified_commercial_transactions": "特定商取引法に基づく表記",
-  "sponsors_description": "スポンサー募集中です!"
+  "sponsors_description": "スポンサー募集中です!",
+  "sponsors_application_closed": "スポンサーの募集は<wbr/>終了いたしました。<wbr/>ホームページへの反映は<wbr/>順次行って参ります。"
 }


### PR DESCRIPTION
## 概要
すべてのスポンサープランの募集が3/31を以て締め切られたので Web サイトから募集要項へのリンクを削除して文言を修正する。
ref: https://goconjp.slack.com/archives/C042B8LHA4R/p1680324447253439

## 変更
- `SponsorsSection` のボタンを削除
- `SponsorsSection` の gopher の配置について、ボタンがなくなったことによるズレなどを修正
- `SponsorsSection` の `sponsors_description` (スポンサー募集中です！ / We are looking for sponsors!) を `sponsors_application_closed` (スポンサーの募集は終了いたしました。ホームページへの反映は順次行って参ります。 / Sponsors application has been closed. We will reflect the information on our website in due course.) に変更

## 備考
### PC (タブレット幅以上)
![image](https://user-images.githubusercontent.com/40013676/229329845-e186b595-80c2-4994-8dd5-342117260229.png)

### スマートフォン (タブレット幅以下)
![image](https://user-images.githubusercontent.com/40013676/229329851-60fc6b47-4f25-46a0-ac39-1953fb2b81ce.png)

