### PR TITLE
feat: Add schema validation for result of Sessionize API

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-i18next": "11.18.6",
     "react-rewards": "^2.0.4",
     "swr": "2.0.3",
-    "use-local-storage-state": "18.1.1"
+    "use-local-storage-state": "18.1.1",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@babel/core": "7.19.3",

--- a/src/modules/sessionize/hooks.ts
+++ b/src/modules/sessionize/hooks.ts
@@ -1,6 +1,26 @@
-import useSWR, { Fetcher } from 'swr'
+import useSWR from 'swr'
+import { sessionizeViewAllSchema, SessionizeViewAllSchemaType } from './schema'
 
-const fetcher: Fetcher<string> = (url: string): Promise<any> => fetch(url).then(res => res.json())
-export const useSessionize = () => {
-  return useSWR(`https://sessionize.com/api/v2/${process.env.NEXT_PUBLIC_SESSIONIZE_ID}/view/All`, fetcher)
+const fetcher = (url: string): Promise<SessionizeViewAllSchemaType> => fetch(url).then(res => res.json())
+export const useSessionize = (): SessionizeViewAllSchemaType | null => {
+  const { data, error } = useSWR(
+    `https://sessionize.com/api/v2/${process.env.NEXT_PUBLIC_SESSIONIZE_ID}/view/All`,
+    fetcher
+  )
+
+  if (error) {
+    console.error(error)
+    return null
+  }
+  if (!data) {
+    return null
+  }
+
+  const parsedResult = sessionizeViewAllSchema.safeParse(data)
+  if (!parsedResult.success) {
+    console.error(parsedResult.error)
+    return null
+  }
+
+  return parsedResult.data
 }

--- a/src/modules/sessionize/schema.ts
+++ b/src/modules/sessionize/schema.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+
+const sessionizeSessionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  startsAt: z.string(),
+  endsAt: z.string(),
+  isServiceSession: z.boolean(),
+  isPlenumSession: z.boolean(),
+  speakers: z.array(z.string()),
+  categoryItems: z.array(z.number()),
+  questionAnswers: z.array(z.string()),
+  roomId: z.number(),
+  liveUrl: z.null(),
+  recordingUrl: z.null(),
+  status: z.literal('Accepted')
+})
+
+const sessionizeSpeakerSchema = z.object({
+  id: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  bio: z.string(),
+  tagLine: z.string(),
+  profilePicture: z.string(),
+  isTopSpeaker: z.boolean(),
+  links: z.array(
+    z.object({
+      linkType: z.string(),
+      title: z.string(),
+      url: z.string()
+    })
+  ),
+  sessions: z.array(z.number()),
+  fullName: z.string(),
+  categoryItems: z.array(z.number()),
+  questionAnswers: z.array(z.string())
+})
+
+const sessionizeCategorySchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  items: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+      sort: z.number()
+    })
+  ),
+  sort: z.number(),
+  type: z.literal('session')
+})
+
+const sessionizeRoomSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  sort: z.number()
+})
+
+/**
+ * Zod schema object for parsing the response from Sessionize's "View All" API.
+ */
+export const sessionizeViewAllSchema = z.object({
+  sessions: z.array(sessionizeSessionSchema),
+  speakers: z.array(sessionizeSpeakerSchema),
+  questions: z.array(z.any()),
+  categories: z.array(sessionizeCategorySchema),
+  rooms: z.array(sessionizeRoomSchema)
+})
+
+/**
+ * Type definition for the parsed response from Sessionize's "View All" API.
+ */
+export type SessionizeViewAllSchemaType = z.infer<typeof sessionizeViewAllSchema>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12045,6 +12045,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
+
 zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"


### PR DESCRIPTION
## 概要
Sessionize API へのリクエスト結果を型安全に使用するために [`zod`](https://zod.dev/) を使った schema 定義と `useSessionize` 内での validation を追加しました。

## 変更
- `yarn add zod`
- `src/modules/sessionize/schema.ts` に Sessionize API の取得結果を元に zod を使った schema オブジェクト (`sessionizeViewAllSchema`) の定義と型 (`SessionizeViewAllSchemaType`) 定義を追加
- `useSessionize` 内でエラーハンドリングと schema validation を追加して、戻り値を `SessionizeViewAllSchemaType | null` に変更

## 使用例
```tsx
import { useSessionize } from 'src/modules/sessionize/hooks'

export const Foo: FC = () => {
  const data = useSessionize()
  if (!data) {
    return <p>Loading...</p>
  }

  ...
}
```