### PR TITLE
chore: Fix some deps to with exact version & Add a config `save-exact=true` in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "11.18.6",
-    "react-rewards": "^2.0.4",
+    "react-rewards": "2.0.4",
     "swr": "2.0.3",
     "use-local-storage-state": "18.1.1",
-    "zod": "^3.21.4"
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@babel/core": "7.19.3",
@@ -49,7 +49,7 @@
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
     "storybook-addon-material-ui5": "1.0.0",
-    "storybook-addon-next": "^1.6.9",
+    "storybook-addon-next": "1.6.9",
     "typescript": "4.8.2"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9834,7 +9834,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-rewards@^2.0.4:
+react-rewards@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-rewards/-/react-rewards-2.0.4.tgz#617f6c1bb591f74bb0e0455cc6ff355ee6d36665"
   integrity sha512-Lw7gIhD8yPDzC6boaVmcXwuTHRLSLAdqB3kZc+29YWvdHWsuc3fdAZlxI8Cm8fvD8fhP+3JkZBtzX224czw15w==
@@ -10752,7 +10752,7 @@ storybook-addon-material-ui5@1.0.0:
     js-beautify "^1.8.9"
     react-inspector "^2.3.1"
 
-storybook-addon-next@^1.6.9:
+storybook-addon-next@1.6.9:
   version "1.6.9"
   resolved "https://registry.yarnpkg.com/storybook-addon-next/-/storybook-addon-next-1.6.9.tgz#ee88b522fa294a5144891c8439300eb7a67b014d"
   integrity sha512-MrzR+Zw4Dzl0mh5C8xPW4suUqh+Sh6/iEXGU5ehW9e1TMavlFbic84xTErHsKrIYNb4jpExsYob4hlhzLqxOjw==
@@ -12045,7 +12045,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.21.4:
+zod@3.21.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
   integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
## 概要
`package.json` にて、いくつかの依存関係のバージョンに `^` が付与されていたのを削除して再インストールして `yarn.lock` を更新しました。また、再発防止のために `.npmrc` を作成して `save-exact=true` を設定しました。

ref: https://github.com/GoCon/2023/pull/183#discussion_r1155305041

## 変更内容
- chore: Install deps with exact version
- chore: Add a config `save-exact=true` in `.npmrc`

## 動作確認
ローカルで適当な deps を yarn add してみて prefix なしのバージョンで追加されたことを確認しました。
