### PR TITLE
chore: Add a workflow to create PR to main automatically

### DIFF
--- a/.git-pr-release
+++ b/.git-pr-release
@@ -1,0 +1,5 @@
+[pr-release "branch"]
+    staging = develop
+    production = main
+[pr-release]
+    template = .github/git-pr-release.erb

--- a/.github/git-pr-release.erb
+++ b/.github/git-pr-release.erb
@@ -1,0 +1,13 @@
+Release <%= Time.now.strftime("%Y-%m-%d %H:%M:%S") %>
+
+## 概要
+
+`develop` ブランチの変更内容を `main` ブランチへマージします。
+
+**この PR はコンフリクト解消のため Squash and merge ではなく Create a merge commit の手法でマージします。**
+
+## 変更内容
+
+<% pull_requests.each do |pr| -%>
+  <%=  pr.to_checklist_item %>
+<% end -%>

--- a/.github/workflows/create-pr-develop-to-main.yml
+++ b/.github/workflows/create-pr-develop-to-main.yml
@@ -1,0 +1,26 @@
+name: Create a pull request from develop to main
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  r2m-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Ruby 3.0.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.1
+      - name: Execute git-pr-release (develop -> main)
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TZ: Asia/Tokyo
+        run: |
+          gem install git-pr-release
+          git remote set-url origin "https://${GITHUB_ACTOR}:${GIT_PR_RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git-pr-release --squashed || echo "Done."


### PR DESCRIPTION
## 概要

`git-pr-release` を使って `develop` から `main` への PR を自動作成するワークフローを追加します。サイト自体に影響はないのでレビューはスキップします。