### PR TITLE
fix: Set aspectRatio to the box out of main visual and Render image a…

### DIFF
--- a/src/components/organisms/MainVisual/index.tsx
+++ b/src/components/organisms/MainVisual/index.tsx
@@ -10,13 +10,13 @@ export const MainVisual = () => {
   const { isTabletOrOver } = useSize()
   const keyVisualWithText = isTabletOrOver ? KeyVisualWithTextPc : KeyVisualWithTextMobile
   const confettiLeftConfig = {
-    angle: isTabletOrOver ? 45 : 90,
+    angle: 45,
     colors: confettiColors,
     elementSize: 12,
     position: 'absolute'
   }
   const confettiRightConfig = {
-    angle: isTabletOrOver ? 135 : 90,
+    angle: 135,
     colors: confettiColors,
     elementSize: 12,
     position: 'absolute'

--- a/src/components/organisms/MainVisual/index.tsx
+++ b/src/components/organisms/MainVisual/index.tsx
@@ -4,6 +4,7 @@ import { useReward } from 'react-rewards'
 import { confettiColors } from 'src/styles/color'
 import Image from 'next/image'
 import { KeyVisualWithTextPc, KeyVisualWithTextMobile } from './images'
+import { useEffect, useState } from 'react'
 
 export const MainVisual = () => {
   const { isTabletOrOver } = useSize()
@@ -54,6 +55,11 @@ export const MainVisual = () => {
     true // call the function immediately after rendered
   )
 
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
   return (
     <Box sx={{ width: '100%', overflow: 'hidden' }}>
       <Box
@@ -65,18 +71,27 @@ export const MainVisual = () => {
         }}
       >
         <Box id="confettiTopLeft" sx={{ position: 'absolute', left: '32px' }} />
-        <Box sx={{ maxWidth: '1440px', margin: '0 auto' }}>
-          <Image
-            src={keyVisualWithText}
-            alt="Go Conference 2023 Online at Friday, June Second"
-            style={{
-              width: '100%',
-              height: 'auto',
-              objectFit: 'contain'
-            }}
-            quality={100}
-            priority
-          />
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: '1440px',
+            aspectRatio: { xs: '748/1114', sm: '1440/845' },
+            margin: '0 auto'
+          }}
+        >
+          {mounted && (
+            <Image
+              src={keyVisualWithText}
+              alt="Go Conference 2023 Online at Friday, June Second"
+              style={{
+                width: '100%',
+                verticalAlign: 'middle',
+                objectFit: 'contain'
+              }}
+              quality={100}
+              priority
+            />
+          )}
         </Box>
         <Box id="confettiTopRight" sx={{ position: 'absolute', right: '32px' }} />
       </Box>


### PR DESCRIPTION
## 概要

メインビジュアルの読み込み時にレイアウトシフトが発生していたので修正しました。軽微な修正のためレビューはスキップします。

## 原因

viewport 幅 600px 未満の時はスマホ用、それ以外は PC 用の画像をレンダリングするという切り替え処理を `isTabletOrOver` という state で行っていましたが、 `isTabletOrOver` はブラウザで読み込んで幅が計算できるまで false を返すため初期描画において PC 幅で表示しているのに false なので スマホ用の画像が一瞬だけレンダリングされてしまいレイアウトシフトが発生していました。

## 解決方法

mounted という state で、 依存配列のない useEffect で true にセットすることで初期レンダリングが完了したタイミングで true になるフラグを用意しました。これが true の時に Image をレンダリングするという条件を付与することで幅が確定したタイミングで画像を表示することができます。

しかし、画像の高さが事前に決まっていないと親要素の Box は高さを持つことができずにメインビジュアルを表示する領域が一瞬だけ折りたたまれるような見え方をしてしまい、画像の切り替えとは別のレイアウトシフトが発生してしまうため、 Image の親要素の Box に 画像の幅、高さと同じ aspectRatio を持つように設定して、画像表示前に表示領域の高さを確保するようにして、レイアウトシフトを抑えました。