### PR TITLE
feat: Add staff page

### DIFF
--- a/src/components/molecules/StaffCard/StaffCard.stories.tsx
+++ b/src/components/molecules/StaffCard/StaffCard.stories.tsx
@@ -1,0 +1,23 @@
+import { StoryObj, Meta } from '@storybook/react'
+import { StaffCard } from '.'
+
+const meta: Meta<typeof StaffCard> = {
+  component: StaffCard
+}
+export default meta
+
+export const Default: StoryObj<typeof StaffCard> = {
+  parameters: {
+    backgrounds: {
+      default: 'secondary'
+    }
+  },
+  args: {
+    name: 'Kiyokawa Taiga',
+    icon: 'https://avatars.githubusercontent.com/u/40013676',
+    organizationName: '株式会社マネーフォワード',
+    twitterLink: 'https://twitter.com/taigakiyokawa',
+    githubLink: 'https://github.com/taigakiyokawa',
+    otherLink: 'https://zenn.dev/taigakiyokawa'
+  }
+}

--- a/src/components/molecules/StaffCard/index.tsx
+++ b/src/components/molecules/StaffCard/index.tsx
@@ -1,0 +1,65 @@
+import { Typography } from '@mui/material'
+import Grid from '@mui/material/Unstable_Grid2'
+import { type FC } from 'react'
+import Image from 'next/image'
+import { Colors } from 'src/styles/color'
+import { Twitter as TwitterIcon, GitHub as GitHubIcon, Link as LinkIcon } from '@mui/icons-material'
+import { type StaffInfo } from 'src/modules/staff'
+
+type Props = StaffInfo
+
+export const StaffCard: FC<Props> = ({ name, icon, organizationName, twitterLink, githubLink, otherLink }) => {
+  return (
+    <Grid
+      container
+      spacing={2}
+      sx={{
+        flexDirection: { xs: 'row', sm: 'column' },
+        justifyContent: { xs: 'flex-start', sm: 'center' },
+        flexGrow: 1,
+        alignItems: 'center',
+        backgroundColor: Colors.background.primary,
+        p: 3,
+        borderRadius: '20px'
+      }}
+    >
+      <Grid>
+        <Image
+          src={icon}
+          alt={`${name}'s icon`}
+          width={120}
+          height={120}
+          style={{ objectFit: 'contain', borderRadius: '50%' }}
+          unoptimized
+        />
+      </Grid>
+      <Grid sx={{ flexGrow: 1, display: 'grid', placeContent: 'center', gap: 3 }}>
+        <Grid sx={{ display: 'flex', flexDirection: 'column', gap: 1, textAlign: 'center' }}>
+          <Typography variant="h4">{name}</Typography>
+          {organizationName && (
+            <Typography variant="subtitle1" sx={{ color: Colors.text.secondary }}>
+              {organizationName}
+            </Typography>
+          )}
+        </Grid>
+        <Grid sx={{ display: 'flex', justifyContent: 'center', gap: 2 }}>
+          {twitterLink && (
+            <a href={twitterLink} target="_blank">
+              <TwitterIcon sx={{ color: Colors.text.primary, ':hover': { color: Colors.text.secondary } }} />
+            </a>
+          )}
+          {githubLink && (
+            <a href={githubLink} target="_blank">
+              <GitHubIcon sx={{ color: Colors.text.primary, ':hover': { color: Colors.text.secondary } }} />
+            </a>
+          )}
+          {otherLink && (
+            <a href={otherLink} target="_blank">
+              <LinkIcon sx={{ color: Colors.text.primary, ':hover': { color: Colors.text.secondary } }} />
+            </a>
+          )}
+        </Grid>
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -62,6 +62,7 @@ export const Header = () => {
       // TODO(taigakiyokawa): Revert to `/timetable` when the page has implemented.
       { href: 'https://sessionize.com/api/v2/jmtn42ls/view/GridSmart', label: 'Timetable', openNewTab: true },
       { href: '/floor_guide', label: 'Floor Guide' },
+      { href: '/staff', label: 'Staff' },
       {
         label: t('change_language'),
         onClick: handleChangeLanguage

--- a/src/components/organisms/StaffCardList/StaffCardList.stories.tsx
+++ b/src/components/organisms/StaffCardList/StaffCardList.stories.tsx
@@ -1,0 +1,19 @@
+import { StoryObj, Meta } from '@storybook/react'
+import { StaffCardList } from '.'
+import { staff } from 'src/modules/staff'
+
+const meta: Meta<typeof StaffCardList> = {
+  component: StaffCardList
+}
+export default meta
+
+export const Default: StoryObj<typeof StaffCardList> = {
+  parameters: {
+    backgrounds: {
+      default: 'secondary'
+    }
+  },
+  args: {
+    staff: staff
+  }
+}

--- a/src/components/organisms/StaffCardList/index.tsx
+++ b/src/components/organisms/StaffCardList/index.tsx
@@ -1,0 +1,27 @@
+import Grid from '@mui/material/Unstable_Grid2'
+import { FC } from 'react'
+import { StaffCard } from 'src/components/molecules/StaffCard'
+import { StaffInfo } from 'src/modules/staff'
+
+type Props = {
+  staff: StaffInfo[]
+}
+
+export const StaffCardList: FC<Props> = ({ staff }) => {
+  return (
+    <Grid container spacing={4} sx={{ maxWidth: '1024px', margin: '0 auto' }}>
+      {staff.map(({ name, icon, organizationName, twitterLink, githubLink, otherLink }, i) => (
+        <Grid key={i} xs={12} sm={6} lg={4} sx={{ display: 'flex' }}>
+          <StaffCard
+            name={name}
+            icon={icon}
+            organizationName={organizationName}
+            twitterLink={twitterLink}
+            githubLink={githubLink}
+            otherLink={otherLink}
+          />
+        </Grid>
+      ))}
+    </Grid>
+  )
+}

--- a/src/modules/staff/index.ts
+++ b/src/modules/staff/index.ts
@@ -1,0 +1,121 @@
+/**
+ * Each staff information
+ */
+export type StaffInfo = {
+  name: string
+  icon: string
+  organizationName?: string
+  twitterLink?: string
+  githubLink?: string
+  otherLink?: string
+}
+
+/**
+ * Staff information list used in `/staff` page.
+ */
+export const staff: StaffInfo[] = [
+  {
+    name: '山口能迪',
+    organizationName: 'グーグル合同会社',
+    icon: 'https://pbs.twimg.com/profile_images/1384005345454936073/Jw2W3sIG_400x400.jpg',
+    twitterLink: 'https://twitter.com/ymotongpoo',
+    githubLink: 'https://github.com/ymotongpoo'
+  },
+  {
+    name: 'micchie',
+    organizationName: '株式会社メルペイ',
+    icon: 'https://pbs.twimg.com/profile_images/1120265745215021056/FN-52cpe_400x400.png',
+    twitterLink: 'https://twitter.com/micchiebear',
+    githubLink: 'https://github.com/mi-bear'
+  },
+  {
+    name: 'luccafort',
+    organizationName: '株式会社マネーフォワード',
+    icon: 'https://pbs.twimg.com/profile_images/877545573787684864/rVHjLVrH_400x400.jpg',
+    twitterLink: 'https://twitter.com/luccafort',
+    githubLink: 'https://github.com/luccafort/'
+  },
+  {
+    name: 'terry',
+    organizationName: '株式会社Showcase Gig',
+    icon: 'https://pbs.twimg.com/profile_images/1580561046615777280/QrNTlXF0_400x400.jpg',
+    twitterLink: 'https://twitter.com/1019hiroya/',
+    githubLink: 'https://github.com/Hiroya3'
+  },
+  {
+    name: 'sivchari',
+    organizationName: 'CyberAgent',
+    icon: 'https://pbs.twimg.com/profile_images/1605935801862606848/wClgAXFu_400x400.jpg',
+    twitterLink: 'https://twitter.com/sivchari',
+    githubLink: 'https://github.com/sivchari'
+  },
+  {
+    name: 'Kiyokawa Taiga',
+    organizationName: '株式会社マネーフォワード',
+    icon: 'https://avatars.githubusercontent.com/u/40013676?v=4',
+    twitterLink: 'https://twitter.com/taigakiyokawa',
+    githubLink: 'https://github.com/taigakiyokawa'
+  },
+  {
+    name: 'sadah',
+    organizationName: '株式会社メルコイン',
+    icon: 'https://sadah.dev/images/icon.jpg',
+    twitterLink: 'https://twitter.com/sada_h',
+    githubLink: 'https://github.com/sadah'
+  },
+  {
+    name: 'Senoue',
+    organizationName: 'Videomarket Co., Ltd.',
+    icon: 'https://avatars.githubusercontent.com/u/3499852?v=4',
+    twitterLink: 'https://twitter.com/senoue',
+    githubLink: 'https://github.com/senoue'
+  },
+  {
+    name: 'goro',
+    organizationName: '株式会社メルコイン',
+    icon: 'https://ca.slack-edge.com/TPU5J9YF7-UPV0X7DDW-afe957bb76f3-512',
+    twitterLink: 'https://twitter.com/awakot_56',
+    githubLink: 'https://github.com/awakot'
+  },
+  {
+    name: 'Shinji NAKAMATSU',
+    organizationName: '株式会社オカキチ',
+    icon: 'https://pbs.twimg.com/profile_images/3411045748/cd6597576c6dea78cf141d9d6829a225_400x400.jpeg',
+    twitterLink: 'https://twitter.com/snaka',
+    githubLink: 'https://github.com/snaka'
+  },
+  {
+    name: 'budougumi0617',
+    organizationName: '株式会社LayerX',
+    icon: 'https://avatars.githubusercontent.com/u/1883265',
+    twitterLink: 'https://twitter.com/budougumi0617',
+    githubLink: 'https://github.com/budougumi0617'
+  },
+  {
+    name: 'Ryuji Iwata',
+    icon: 'https://pbs.twimg.com/profile_images/3392135250/937e2b8360125506e58f3dcb0ccb78fb_400x400.png',
+    twitterLink: 'https://twitter.com/qt_luigi',
+    githubLink: 'https://github.com/qt-luigi',
+    otherLink: 'https://sites.google.com/view/ryuji-iwata-portfolio'
+  },
+  {
+    name: 'mikichin',
+    organizationName: '株式会社メルペイ',
+    icon: 'https://pbs.twimg.com/profile_images/1420563286051876866/-q0VIQhE_400x400.jpg',
+    twitterLink: 'https://twitter.com/chida_miki'
+  },
+  {
+    name: '伊藤真彦',
+    organizationName: '株式会社オカキチ',
+    icon: 'https://pbs.twimg.com/profile_images/1233957245764812800/pi0XtJrr_400x400.jpg',
+    twitterLink: 'https://twitter.com/it_guitar',
+    githubLink: 'https://github.com/maito1201'
+  },
+  {
+    name: 'linjiansi',
+    organizationName: 'からくり株式会社',
+    icon: 'https://avatars.githubusercontent.com/u/55640271?v=4',
+    twitterLink: 'https://twitter.com/linjiansi_dev',
+    githubLink: 'https://github.com/linjiansi'
+  }
+]

--- a/src/pages/staff.tsx
+++ b/src/pages/staff.tsx
@@ -1,0 +1,21 @@
+import { Box, Typography } from '@mui/material'
+import type { NextPage } from 'next'
+import { Layout } from 'src/components/commons'
+import { StaffCardList } from 'src/components/organisms/StaffCardList'
+import { staff } from 'src/modules/staff'
+import { Colors } from 'src/styles/color'
+
+export const Page: NextPage = () => {
+  return (
+    <Layout>
+      <Box sx={{ backgroundColor: Colors.background.secondary }}>
+        <Typography variant="h2" sx={{ paddingTop: { xs: '64px', sm: '128px' }, textAlign: 'center' }}>
+          Staff
+        </Typography>
+        <StaffCardList staff={staff} />
+      </Box>
+    </Layout>
+  )
+}
+
+export default Page


### PR DESCRIPTION
## 概要

スタッフ一覧ページを作成しました。現時点でフォームに回答のあった順に掲載しています。掲載情報はフリガナを除いて基本的にフォームで回答いただいた通りですが、一部、同じ会社と思われる方の表記がゆれているものは一方に統一しました。

## スクリーンショット

### PC

![Screenshot 2023-05-23 at 21 01 32](https://github.com/GoCon/2023/assets/40013676/5499090d-3bf1-4de7-8802-18805f5877a2)

![Screenshot 2023-05-23 at 21 01 46](https://github.com/GoCon/2023/assets/40013676/6b7d17ec-9b72-4a5e-a2cd-d12164014c87)


### Mobile

![Screenshot 2023-05-23 at 21 02 15](https://github.com/GoCon/2023/assets/40013676/e35d68fa-6f43-43b9-9848-b9b132e37d43)

![Screenshot 2023-05-23 at 21 02 23](https://github.com/GoCon/2023/assets/40013676/a228f731-b20f-43b8-8972-ee048fafdad6)

![Screenshot 2023-05-23 at 21 02 49](https://github.com/GoCon/2023/assets/40013676/97154e99-1909-4440-88bc-e94e1b93f894)
