### PR TITLE
feat: Add tottie-san's info

### DIFF
--- a/src/modules/staff/index.ts
+++ b/src/modules/staff/index.ts
@@ -117,5 +117,12 @@ export const staff: StaffInfo[] = [
     icon: 'https://avatars.githubusercontent.com/u/55640271?v=4',
     twitterLink: 'https://twitter.com/linjiansi_dev',
     githubLink: 'https://github.com/linjiansi'
+  },
+  {
+    name: 'tottie',
+    organizationName: 'Mercari, Inc.',
+    icon: 'https://pbs.twimg.com/profile_images/1124153474961199106/V7E2OuyH_400x400.jpg',
+    twitterLink: 'https://twitter.com/tottie_designer',
+    githubLink: 'https://github.com/tottie000'
   }
 ]


### PR DESCRIPTION
## 概要

スタッフ一覧ページ `/staff` について、 tottie さんにもご回答いただいたので名前やアイコンなどを追加しました。

## スクリーンショット

### PC

![Screenshot 2023-05-24 at 20 51 22](https://github.com/GoCon/2023/assets/40013676/afd82751-c4c7-4b9e-ab2c-1d437dd0a852)

### Mobile

![Screenshot 2023-05-24 at 20 51 03](https://github.com/GoCon/2023/assets/40013676/19fc5ed5-18a8-4670-8107-a23de23ef90a)
