### PR TITLE
hotfix: Add touch out/.nojekyll

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   swcMinify: true,
   assetPrefix: '/2023',
   basePath: '/2023',
+  output: 'export',
   trailingSlash: true,
   images: {
     unoptimized: true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build && touch out/.nojekyll",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{ts,tsx}\"",


### PR DESCRIPTION
GitHub Pages は `_next` 以下の JS をページとして読み込んでくれないらしい。 `out/` に `.nojekyll` というファイルを作成することでこれを解決できるらしい。

https://qiita.com/ozaki25/items/fe9912fc41c3a5c5bfea#%E3%81%AF%E3%81%BE%E3%82%8A%E3%81%A9%E3%81%93%E3%82%8Djs%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%8C404%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86%E5%95%8F%E9%A1%8C


公式の手順でも入れていた

https://github.com/vercel/next.js/tree/canary/examples/github-pages