### PR TITLE
hotfix: Add .nojekyll to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && touch out/.nojekyll",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{ts,tsx}\"",


### PR DESCRIPTION
build 後に touch しても動かなかったので

ref: [sub-t/blog-template: Next.js + markdown Blog Template](https://github.com/sub-t/blog-template/tree/main)
[Next.js + GitHub Pagesのブログテンプレートを作った](https://zenn.dev/subt/articles/957bd5d01485e1)