### PR TITLE
tmp: Revert link to sessions to the page built by sessionize

### DIFF
--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -57,7 +57,8 @@ export const Header = () => {
   const menuList: HeaderMenuItem[] = useMemo(() => {
     return [
       { href: '/', label: 'Home' },
-      { href: '/sessions', label: 'Sessions' },
+      // TODO(taigakiyokawa): Revert to `/timetable` when the page has implemented.
+      { href: 'https://sessionize.com/api/v2/jmtn42ls/view/sessions', label: 'Sessions', openNewTab: true },
       // TODO(taigakiyokawa): Revert to `/timetable` when the page has implemented.
       { href: 'https://sessionize.com/api/v2/jmtn42ls/view/GridSmart', label: 'Timetable', openNewTab: true },
       { href: '/floor_guide', label: 'Floor Guide' },


### PR DESCRIPTION
セッション一覧をはじめとする複数のページがブラウザリロードによって 404 エラーになる問題が発生しているため、解決するまでヘッダーの Sessions のリンクを sessionize がビルドしたページに差し戻します