### PR TITLE
fix: static site generate

### DIFF
--- a/src/pages/floor_guide.tsx
+++ b/src/pages/floor_guide.tsx
@@ -1,7 +1,14 @@
+import { GetStaticProps } from 'next'
+
 import { PageFloorGuide } from 'src/components/pages'
 
 const Index = () => {
   return <PageFloorGuide />
+}
+
+// NOTE: next exportで静的ファイルとして生成するため空のpropsを宣言する
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} }
 }
 
 export default Index

--- a/src/pages/sessions.tsx
+++ b/src/pages/sessions.tsx
@@ -1,7 +1,13 @@
+import { GetStaticProps } from 'next'
 import { PageSessions } from 'src/components/pages'
 
 const Index = () => {
   return <PageSessions />
+}
+
+// NOTE: next exportで静的ファイルとして生成するため空のpropsを宣言する
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} }
 }
 
 export default Index

--- a/src/pages/staff.tsx
+++ b/src/pages/staff.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography } from '@mui/material'
-import type { NextPage } from 'next'
+import type { GetStaticProps, NextPage } from 'next'
 import { Layout } from 'src/components/commons'
 import { StaffCardList } from 'src/components/organisms/StaffCardList'
 import { staff } from 'src/modules/staff'
@@ -16,6 +16,11 @@ export const Page: NextPage = () => {
       </Box>
     </Layout>
   )
+}
+
+// NOTE: next exportで静的ファイルとして生成するため空のpropsを宣言する
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} }
 }
 
 export default Page

--- a/src/pages/timetable.tsx
+++ b/src/pages/timetable.tsx
@@ -1,8 +1,14 @@
+import { GetStaticProps } from 'next'
 import { PageTop } from 'src/components/pages'
 
 const Index = () => {
   /* TODO: 各ページの実装 */
   return <PageTop />
+}
+
+// NOTE: next exportで静的ファイルとして生成するため空のpropsを宣言する
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} }
 }
 
 export default Index


### PR DESCRIPTION
next export実行時に静的HTMLが生成されていなかったので、生成されるようにコードを修正する

![image](https://github.com/GoCon/2023/assets/49754654/9c42ba69-e079-43f9-b10c-ddf64cb00752)
