### PR TITLE
feat: Add tenntenn-san's info

### DIFF
--- a/src/modules/staff/index.ts
+++ b/src/modules/staff/index.ts
@@ -124,5 +124,13 @@ export const staff: StaffInfo[] = [
     icon: 'https://pbs.twimg.com/profile_images/1124153474961199106/V7E2OuyH_400x400.jpg',
     twitterLink: 'https://twitter.com/tottie_designer',
     githubLink: 'https://github.com/tottie000'
+  },
+  {
+    name: 'tenntenn',
+    organizationName: '株式会社ナレッジワーク',
+    icon: 'https://tenntenn.dev/images/tenntenn.png',
+    twitterLink: 'https://twitter.com/tenntenn',
+    githubLink: 'https://github.com/tenntenn',
+    otherLink: 'https://tenntenn.dev'
   }
 ]


### PR DESCRIPTION
tenntenn さんの情報を `/staff` に追加しました。

## スクリーンショット
### PC

![image](https://github.com/GoCon/2023/assets/40013676/af2c55ad-ec91-4ed2-b171-732f6ef651d7)

### Mobile

![Screenshot 2023-05-25 at 21 18 56](https://github.com/GoCon/2023/assets/40013676/fc03065f-ed2d-4b9c-ba7e-c84647cca1b0)
