### PR TITLE
chore: Fix sessions count of description in top page

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,7 +11,7 @@
   "about": "Go Conference is a conference for Go programming language users. It's the 10th anniversary!",
   "check_cfp": "check CfP",
   "session": "session",
-  "session_num": "30 or more sessions(Open call for paper at 2022/12)",
+  "session_num": "32 sessions",
   "target": "target",
   "target_info": "gopher, aspiring engineer, interested in Go",
   "host": "organizer",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -11,7 +11,7 @@
   "check_cfp": "CfPを確認する",
   "about": "Go Conference は<wbr/>プログラミング言語Goユーザーの<wbr/>ための<wbr/>カンファレンスです。<wbr/>今年で10周年!",
   "session": "セッション",
-  "session_num": "30セッション程度(2022年12月公募開始)",
+  "session_num": "32セッション",
   "target": "対象者",
   "target_info": "Goエンジニア、エンジニア志望の方、Goに興味のある方",
   "host": "主催",


### PR DESCRIPTION
トップページのセッションに関する説明を最新の情報に更新しました。

文言についてはセッション班に確認しています 👉  https://goconjp.slack.com/archives/C042B8LHA4R/p1684930102724269

## スクリーンショット

### ja

![Screenshot 2023-05-25 at 21 27 25](https://github.com/GoCon/2023/assets/40013676/1cb5aa7b-db2e-4b17-8ce3-bdc364c6c7a8)


### en

![Screenshot 2023-05-25 at 21 27 34](https://github.com/GoCon/2023/assets/40013676/c157e151-9e38-44ed-a651-7791d26473ea)
