### PR TITLE
fix: Suppress layout shift after loading in sessions list

### DIFF
--- a/src/components/pages/PageSessions/index.tsx
+++ b/src/components/pages/PageSessions/index.tsx
@@ -26,7 +26,8 @@ export const PageSessions: FC = () => {
           display: 'flex',
           justifyContent: 'center',
           backgroundColor: Colors.background.secondary,
-          padding: { xs: '32px 16px', md: '80px 20px' }
+          padding: { xs: '32px 16px', md: '80px 20px' },
+          minHeight: '100vh'
         }}
       >
         <Box maxWidth={'1024px'} width={'100%'}>


### PR DESCRIPTION
## やったこと

セッション一覧の読み込み中に一瞬薄いグレーの背景の下の方に白い部分が現れるのが気になるので、それを見せないようにしました。

| Before | After |
|--------|--------|
| <a href="https://gyazo.com/97fe877a95e1e25dcf329df1e95497ab"><img src="https://i.gyazo.com/97fe877a95e1e25dcf329df1e95497ab.gif" alt="Image from Gyazo" width="350"/></a> | <a href="https://gyazo.com/ea1317f9d947f094e5afb117988280fb"><img src="https://i.gyazo.com/ea1317f9d947f094e5afb117988280fb.gif" alt="Image from Gyazo" width="350"/></a> |

