### PR TITLE
refactor: Reduce build time by caching Sessionize API responses

### DIFF
--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -14,6 +14,7 @@ import { ArrowBackIosNew as ArrowBackIosNewIcon, Event as EventIcon, Twitter as 
 import dayjs from 'dayjs'
 import { useTranslation } from 'react-i18next'
 import NextLink from 'next/link'
+import { SessionizeViewAllSchemaType } from 'src/modules/sessionize/schema'
 
 type Props = {
   title: string
@@ -74,7 +75,18 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }
 }
 
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+/**
+ * Cache sessionize data.
+ */
+let sessionizeCache: SessionizeViewAllSchemaType | undefined = undefined
+
+/**
+ * Fetch sessionize data and cache it.
+ */
+const fetchSessionize: () => Promise<SessionizeViewAllSchemaType> = async () => {
+  if (sessionizeCache) {
+    return sessionizeCache
+  }
   const response = await fetch('https://sessionize.com/api/v2/3qcdixg4/view/All')
   const parsedResult = await sessionizeViewAllSchema.safeParseAsync(await response.json())
 
@@ -82,7 +94,12 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
     throw new Error(`Failed to parse: ${parsedResult.error}`)
   }
 
-  const { sessions, rooms, categories, speakers } = parsedResult.data
+  sessionizeCache = parsedResult.data
+  return sessionizeCache
+}
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const { sessions, rooms, categories, speakers } = await fetchSessionize()
 
   const matchedSession = sessions.find(
     ({ questionAnswers }) =>


### PR DESCRIPTION
静的ページビルド時の Sessionize API の呼び出しが各ページ毎に発生していたので、２回め以降はキャッシュを利用するようにしてみました。
