### PR TITLE
feat: Replace URLs in floor guide descriptios with links

### DIFF
--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -1,5 +1,5 @@
 import { Typography, Box } from '@mui/material'
-import { ReactNode } from 'react'
+import { Fragment, ReactNode } from 'react'
 import { Colors } from 'src/styles/color'
 
 /** Regular expression for parsing URLs (excluding closing parentheses at the end) */
@@ -42,7 +42,7 @@ const replaceUrlWithLink: (text: string) => ReactNode = text => {
         </a>
       )
     } else {
-      return <>{part}</>
+      return <Fragment key={i}>{part}</Fragment>
     }
   })
 }

--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -1,4 +1,44 @@
 import { Typography, Box } from '@mui/material'
+import { ReactNode } from 'react'
+import { Colors } from 'src/styles/color'
+
+// Regular expression for parsing URLs (excluding closing parentheses at the end)
+const URL_REGEX: RegExp = /(https?:\/\/[^)\s)]+)/g
+
+/**
+ * Convert URL strings contained in text to links
+ * @param text text
+ */
+const replaceUrlWithLink: (text: string) => ReactNode = text => {
+  const parts = text.split(URL_REGEX)
+
+  return parts.map((part, i) => {
+    if (part.match(URL_REGEX)) {
+      return (
+        <a key={i} href={part} target="_blank" rel="noopener noreferrer" style={{ color: Colors.text.link }}>
+          {shortenUrl(part)}
+        </a>
+      )
+    } else {
+      return <>{part}</>
+    }
+  })
+}
+
+const MAX_URL_LENGTH = 24
+
+/**
+ * Remove the protocol part from the URL string, and if the length of the entire URL string exceeds 32 characters, replace the 32nd character and beyond with "..."
+ * @param url URL string
+ */
+const shortenUrl: (url: string) => string = url => {
+  const protocolRemoved = url.replace(/(https?:\/\/)/, '')
+  if (protocolRemoved.length > MAX_URL_LENGTH) {
+    return protocolRemoved.slice(0, MAX_URL_LENGTH) + '...'
+  } else {
+    return protocolRemoved
+  }
+}
 
 export interface BoothCardProps {
   title: string
@@ -13,7 +53,7 @@ export const BoothCard = ({ title, description }: BoothCardProps) => {
         variant="body2"
         sx={{ mb: '24px', maxWidth: '680px', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
       >
-        {description}
+        {replaceUrlWithLink(description)}
       </Typography>
     </Box>
   )

--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -15,7 +15,13 @@ const replaceUrlWithLink: (text: string) => ReactNode = text => {
   return parts.map((part, i) => {
     if (part.match(URL_REGEX)) {
       return (
-        <a key={i} href={part} target="_blank" rel="noopener noreferrer" style={{ color: Colors.text.link }}>
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: Colors.text.link, textDecoration: 'underline' }}
+        >
           {shortenUrl(part)}
         </a>
       )

--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -2,8 +2,24 @@ import { Typography, Box } from '@mui/material'
 import { ReactNode } from 'react'
 import { Colors } from 'src/styles/color'
 
-// Regular expression for parsing URLs (excluding closing parentheses at the end)
+/** Regular expression for parsing URLs (excluding closing parentheses at the end) */
 const URL_REGEX: RegExp = /(https?:\/\/[^)\s)]+)/g
+
+/** Maximum number of characters to display URL */
+const MAX_URL_LENGTH: number = 24
+
+/**
+ * Remove the protocol part from the URL string, and if the length of the entire URL string exceeds 32 characters, replace the 32nd character and beyond with "..."
+ * @param url URL string
+ */
+const shortenUrl: (url: string) => string = url => {
+  const protocolRemoved = url.replace(/(https?:\/\/)/, '')
+  if (protocolRemoved.length > MAX_URL_LENGTH) {
+    return protocolRemoved.slice(0, MAX_URL_LENGTH) + '...'
+  } else {
+    return protocolRemoved
+  }
+}
 
 /**
  * Convert URL strings contained in text to links
@@ -29,21 +45,6 @@ const replaceUrlWithLink: (text: string) => ReactNode = text => {
       return <>{part}</>
     }
   })
-}
-
-const MAX_URL_LENGTH = 24
-
-/**
- * Remove the protocol part from the URL string, and if the length of the entire URL string exceeds 32 characters, replace the 32nd character and beyond with "..."
- * @param url URL string
- */
-const shortenUrl: (url: string) => string = url => {
-  const protocolRemoved = url.replace(/(https?:\/\/)/, '')
-  if (protocolRemoved.length > MAX_URL_LENGTH) {
-    return protocolRemoved.slice(0, MAX_URL_LENGTH) + '...'
-  } else {
-    return protocolRemoved
-  }
 }
 
 export interface BoothCardProps {


### PR DESCRIPTION
## やったこと

- Floor Guide のページでコミュニティの説明文に含まれるURLをリンクとして機能するようにしました
    - 表示用の文字列としては `https://` のプロトコル部分は省略しました
    - 文字列の長さが 24 文字を超える部分は `...` として省略するようにしました

## Before / After

| Before | After |
|--------|--------|
| <img src=https://github.com/GoCon/2023/assets/19329/f627a04e-c5f1-440f-9764-9e8a900330d7 width=350> | <img src=https://github.com/GoCon/2023/assets/19329/ecb2e133-88c1-4867-9976-9ba03b53fcb5 width=350> |


