### PR TITLE
feat: Replace URLs with Link in session details

### DIFF
--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -14,7 +14,7 @@ export const BoothCard = ({ title, description }: BoothCardProps) => {
         variant="body2"
         sx={{ mb: '24px', maxWidth: '680px', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
       >
-        {replaceUrlWithLink(description, { keepFullLength: false })}
+        {replaceUrlWithLink(description)}
       </Typography>
     </Box>
   )

--- a/src/components/molecules/BoothCard/index.tsx
+++ b/src/components/molecules/BoothCard/index.tsx
@@ -1,51 +1,5 @@
 import { Typography, Box } from '@mui/material'
-import { Fragment, ReactNode } from 'react'
-import { Colors } from 'src/styles/color'
-
-/** Regular expression for parsing URLs (excluding closing parentheses at the end) */
-const URL_REGEX: RegExp = /(https?:\/\/[^)\s)]+)/g
-
-/** Maximum number of characters to display URL */
-const MAX_URL_LENGTH: number = 24
-
-/**
- * Remove the protocol part from the URL string, and if the length of the entire URL string exceeds 32 characters, replace the 32nd character and beyond with "..."
- * @param url URL string
- */
-const shortenUrl: (url: string) => string = url => {
-  const protocolRemoved = url.replace(/(https?:\/\/)/, '')
-  if (protocolRemoved.length > MAX_URL_LENGTH) {
-    return protocolRemoved.slice(0, MAX_URL_LENGTH) + '...'
-  } else {
-    return protocolRemoved
-  }
-}
-
-/**
- * Convert URL strings contained in text to links
- * @param text text
- */
-const replaceUrlWithLink: (text: string) => ReactNode = text => {
-  const parts = text.split(URL_REGEX)
-
-  return parts.map((part, i) => {
-    if (part.match(URL_REGEX)) {
-      return (
-        <a
-          key={i}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: Colors.text.link, textDecoration: 'underline' }}
-        >
-          {shortenUrl(part)}
-        </a>
-      )
-    } else {
-      return <Fragment key={i}>{part}</Fragment>
-    }
-  })
-}
+import { replaceUrlWithLink } from 'src/modules/util/text'
 
 export interface BoothCardProps {
   title: string
@@ -60,7 +14,7 @@ export const BoothCard = ({ title, description }: BoothCardProps) => {
         variant="body2"
         sx={{ mb: '24px', maxWidth: '680px', wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
       >
-        {replaceUrlWithLink(description)}
+        {replaceUrlWithLink(description, { keepFullLength: false })}
       </Typography>
     </Box>
   )

--- a/src/modules/util/text.tsx
+++ b/src/modules/util/text.tsx
@@ -1,0 +1,57 @@
+import { Fragment, ReactNode } from 'react'
+import { Colors } from 'src/styles/color'
+
+/**
+ * Regular expression for parsing URLs.
+ * Japanese and closing parentheses following the URL are not considered part of the URL
+ */
+const URL_REGEX: RegExp = /(https?:\/\/[^)\s\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]+)/gu
+
+/** Maximum number of characters to display URL */
+const MAX_URL_LENGTH: number = 24
+
+/**
+ * Remove the protocol part from the URL string, and if the length of the entire URL string exceeds 32 characters, replace the 32nd character and beyond with "..."
+ * @param url URL string
+ */
+const shortenUrl: (url: string) => string = url => {
+  const protocolRemoved = url.replace(/(https?:\/\/)/, '')
+  if (protocolRemoved.length > MAX_URL_LENGTH) {
+    return protocolRemoved.slice(0, MAX_URL_LENGTH) + '...'
+  } else {
+    return protocolRemoved
+  }
+}
+
+type ReplaceUrlWithLinkOptions = {
+  /** If true, the URL will be displayed in full length */
+  keepFullLength: boolean
+}
+/**
+ * Convert URL strings contained in text to links
+ * @param text text
+ */
+export const replaceUrlWithLink: (text: string, options: ReplaceUrlWithLinkOptions) => ReactNode = (
+  text,
+  { keepFullLength }
+) => {
+  const parts = text.split(URL_REGEX)
+
+  return parts.map((part, i) => {
+    if (part.match(URL_REGEX)) {
+      return (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: Colors.text.link, textDecoration: 'underline' }}
+        >
+          {keepFullLength ? part : shortenUrl(part)}
+        </a>
+      )
+    } else {
+      return <Fragment key={i}>{part}</Fragment>
+    }
+  })
+}

--- a/src/modules/util/text.tsx
+++ b/src/modules/util/text.tsx
@@ -24,17 +24,19 @@ const shortenUrl: (url: string) => string = url => {
 }
 
 type ReplaceUrlWithLinkOptions = {
-  /** If true, the URL will be displayed in full length */
-  keepFullLength: boolean
+  /** If true, the URL will be displayed in full length. Default as false */
+  keepFullLength?: boolean
 }
 /**
  * Convert URL strings contained in text to links
  * @param text text
  */
-export const replaceUrlWithLink: (text: string, options: ReplaceUrlWithLinkOptions) => ReactNode = (
+export const replaceUrlWithLink: (text: string, options?: ReplaceUrlWithLinkOptions) => ReactNode = (
   text,
-  { keepFullLength }
+  options = {}
 ) => {
+  const { keepFullLength = false } = options
+
   const parts = text.split(URL_REGEX)
 
   return parts.map((part, i) => {

--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -17,6 +17,7 @@ import dayjs from 'dayjs'
 import { useTranslation } from 'react-i18next'
 import NextLink from 'next/link'
 import { SessionizeViewAllSchemaType } from 'src/modules/sessionize/schema'
+import { replaceUrlWithLink } from 'src/modules/util/text'
 
 type Props = {
   title: string
@@ -205,7 +206,7 @@ const Page: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', mb: '24px' }}>
           <SessionLabel roomName={roomName} sessionId={sessionId} isRoomNameDisplayed />
           <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-            {description}
+            {replaceUrlWithLink(description, { keepFullLength: true })}
           </Typography>
           <Box sx={{ display: 'flex' }}>
             <Box sx={{ display: 'flex', gap: '4px' }}>


### PR DESCRIPTION
## やったこと

- [Floor Guide で実施した](https://github.com/GoCon/2023/pull/254) のと同様の対応をセッション詳細ページにも適用した
    - セッション詳細ページは Floor Guide とは異なり表示領域に余裕があるので URL を省略せずにそのまま表示するように対応した

## Screen shots

URL を含むセッション詳細ページの例

例1) http://localhost:3000/2023/sessions/A10-S/
<img src=https://github.com/GoCon/2023/assets/19329/bc78550b-54b6-4b6c-b66d-2193805c424f width=600>

例2) http://localhost:3000/2023/sessions/B4-S/
<img src=https://github.com/GoCon/2023/assets/19329/7f862d11-ea64-4b3a-9090-dc7acd1ed7ca width=600>

