### PR TITLE
chore: Cache node_modules with `actions/cache` instead of caching with `actions/setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,34 +4,53 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
-          cache: yarn
-      - name: Cache next build
+
+      - name: Cache build
         uses: actions/cache@v3
+        id: cache_build
         with:
-          path: ${{ github.workspace }}/.next/cache
+          path: |
+            '**/node_modules'
+            ${{ github.workspace }}/.next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
+            ${{ runner.os }}-build-${{ hashFiles('**/yarn.lock') }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Echo cache build outputs
+        run: echo '${{ toJSON(steps.cache_build.outputs) }}'
+
       - name: Create .env file
         run: |
           echo "${{ secrets.ENV }}" > .env
+
       - name: Install deps
+        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn install --frozen-lockfile
+
       - name: Lint
+        # next lint caches .next/cache/eslint
+        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn lint
+
       - name: Build
+        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn build
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
CI の Post setup Node.js というステップに 2m くらいかかっていたので短縮します。

`actions/setup-node` で yarn のキャッシュをしていたのを止めて、 `actions/cache` で next のキャッシュと同様に node_modules のキャッシュをするように変更し、キャッシュが存在する場合は各種ステップをスキップするように条件文を追加しました。