### PR TITLE
fix: Replace URL string in bio with Link

### DIFF
--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -265,7 +265,7 @@ const Page: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
               </MuiLink>
             )}
           </Box>
-          <Typography variant="body2">{bio}</Typography>
+          <Typography variant="body2">{replaceUrlWithLink(bio, { keepFullLength: true })}</Typography>
         </Box>
       </Box>
 


### PR DESCRIPTION
Speaker の `bio` に URL を記載しているケースも発見したので対応しました 🙏  (五月雨ですみません 🙇 )

- URLを記載されていた方
    - http://localhost:3000/2023/sessions/A11-S/
