### PR TITLE
hotfix: Remove skipping build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         run: yarn lint
 
       - name: Build
-        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn build
 
       - name: Deploy


### PR DESCRIPTION
gh-pages のアウトプットが全部消えたので next build はスキップしちゃダメそうだった。 