### PR TITLE
hotfix: Remove skipping all steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,9 @@ jobs:
           echo "${{ secrets.ENV }}" > .env
 
       - name: Install deps
-        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn install --frozen-lockfile
 
       - name: Lint
-        # next lint caches .next/cache/eslint
-        if: ${{ steps.cache_build.outputs.cache-hit != 'true' }}
         run: yarn lint
 
       - name: Build


### PR DESCRIPTION
おそらく deps が見つからないことによりビルドが失敗したので、一旦全部の if 分岐をなくして install も lint も実行されるように修正