### PR TITLE
feat: change title of meta_tag by pages

### DIFF
--- a/src/components/commons/Layout/index.tsx
+++ b/src/components/commons/Layout/index.tsx
@@ -18,12 +18,12 @@ export interface LayoutProps {
 export const Layout: NextPage<LayoutProps> = ({ children }) => {
   const router = useRouter()
   const [authorized, setAuthorized] = useLocalStorageState('authorized', { defaultValue: false })
-  const pageName = useMemo(() => {
-    const pageName = router.pathname.replaceAll('/', '')
-    if (pageName === '') return 'Home'
+  const pageTitle = useMemo(() => {
+    const title = router.pathname.replaceAll('/', '')
+    if (title === '') return 'Home'
 
     // NOTE: snake_caseの文字列を大文字始まり、スペース区切りに変換
-    return pageName
+    return title
       .split('_')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
       .join(' ')
@@ -53,7 +53,7 @@ export const Layout: NextPage<LayoutProps> = ({ children }) => {
   return (
     <>
       <Head>
-        <title>{`${pageName} | Go Conference 2023`}</title>
+        <title>{`${pageTitle} | Go Conference 2023`}</title>
         <base href={config.basePath + '/'} />
         <link rel="icon" href={config.basePath + '/favicon.ico'} />
         <meta name="description" content="Go Conference is a conference for Go programming language users." />

--- a/src/components/commons/Layout/index.tsx
+++ b/src/components/commons/Layout/index.tsx
@@ -1,7 +1,8 @@
 import config from '../../../../next.config'
 import type { NextPage } from 'next'
-import { ReactNode, ChangeEvent } from 'react'
+import { ReactNode, ChangeEvent, useMemo } from 'react'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 
 import { Header } from 'src/components/organisms'
 import { Footer } from 'src/components/organisms'
@@ -15,7 +16,18 @@ export interface LayoutProps {
 }
 
 export const Layout: NextPage<LayoutProps> = ({ children }) => {
+  const router = useRouter()
   const [authorized, setAuthorized] = useLocalStorageState('authorized', { defaultValue: false })
+  const pageName = useMemo(() => {
+    const pageName = router.pathname.replaceAll('/', '')
+    if (pageName === '') return 'Home'
+
+    // NOTE: snake_caseの文字列を大文字始まり、スペース区切りに変換
+    return pageName
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(' ')
+  }, [router])
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (toSha256(e.target.value) === process.env.NEXT_PUBLIC_AUTH_PASSWORD_HASH) setAuthorized(true)
@@ -41,7 +53,7 @@ export const Layout: NextPage<LayoutProps> = ({ children }) => {
   return (
     <>
       <Head>
-        <title>Go Conference 2023</title>
+        <title>{`${pageName} | Go Conference 2023`}</title>
         <base href={config.basePath + '/'} />
         <link rel="icon" href={config.basePath + '/favicon.ico'} />
         <meta name="description" content="Go Conference is a conference for Go programming language users." />

--- a/src/components/pages/PageSponsor/index.tsx
+++ b/src/components/pages/PageSponsor/index.tsx
@@ -4,12 +4,16 @@ import { Layout } from 'src/components/commons'
 import { type SponsorInfo } from 'src/modules/sponsors'
 import Grid from '@mui/material/Unstable_Grid2'
 import { FC } from 'react'
+import Head from 'next/head'
 
 type Props = Omit<SponsorInfo, 'id'>
 
 export const PageSponsor: FC<Props> = ({ name, logo, description }) => {
   return (
     <Layout>
+      <Head>
+        <title>{`${name} | Go Conference 2023`}</title>
+      </Head>
       <Grid container spacing={4} sx={{ maxWidth: '1024px', m: '128px auto 0', px: '16px' }}>
         <Grid xs={12} md={4} sx={{ position: 'relative', aspectRatio: '16/9' }}>
           <Image src={logo} fill alt={name} style={{ objectFit: 'contain' }} />

--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -20,6 +20,7 @@ import {
   getSpeaker,
   getTwitterUserName
 } from 'src/modules/sessionize/utils'
+import Head from 'next/head'
 
 type Props = {
   title: string
@@ -132,6 +133,9 @@ const Page: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   const { t } = useTranslation()
   return (
     <Layout>
+      <Head>
+        <title>{`${title} | Go Conference 2023`}</title>
+      </Head>
       <Box
         sx={{
           my: '128px',


### PR DESCRIPTION
各ページごとにmeta タグのタイトルを設定します

前年度は (<イベント名 > | <各ページのタイトル>)でしたが、タブが多いと埋もれてしまうので
踏襲せず(<各ページのタイトル>  | <イベント名 >)で行きます

![image](https://github.com/GoCon/2023/assets/49754654/137ec5bd-b9e4-4fc0-9caa-fb5c387d5ed2)

![image](https://github.com/GoCon/2023/assets/49754654/dc518785-3421-4c1f-816e-18a7231acd8c)

![image](https://github.com/GoCon/2023/assets/49754654/68ab2cb8-94d4-44b8-a120-f5e6239fc943)

