### PR TITLE
feat: Add `/timetable` page with getStaticProps (for PC only)

### DIFF
--- a/src/components/molecules/HeaderMenu/index.tsx
+++ b/src/components/molecules/HeaderMenu/index.tsx
@@ -16,34 +16,18 @@ export const HeaderMenu = ({ menuList, itemColor, itemBehaviorStyles }: HeaderMe
     <Box sx={{ display: 'flex', gap: '8px', margin: '0 24px 0 auto' }}>
       {menuList.map((list, i) => {
         return list.href ? (
-          list.openNewTab ? (
-            // TODO(taigakiyokawa): Revert using `next/link` when pages have implemented.
-            <a href={list.href} target="_blank" rel="noreferrer" key={i}>
-              <Typography
-                sx={{
-                  borderBottom: router.pathname === list.href ? '3px solid' : '',
-                  color: itemColor.default,
-                  p: '4px 8px',
-                  ...itemBehaviorStyles
-                }}
-              >
-                {list.label}
-              </Typography>
-            </a>
-          ) : (
-            <Link href={list.href} key={i}>
-              <Typography
-                sx={{
-                  borderBottom: router.pathname === list.href ? '3px solid' : '',
-                  color: itemColor.default,
-                  p: '4px 8px',
-                  ...itemBehaviorStyles
-                }}
-              >
-                {list.label}
-              </Typography>
-            </Link>
-          )
+          <Link href={list.href} key={i}>
+            <Typography
+              sx={{
+                borderBottom: router.pathname === list.href ? '3px solid' : '',
+                color: itemColor.default,
+                p: '4px 8px',
+                ...itemBehaviorStyles
+              }}
+            >
+              {list.label}
+            </Typography>
+          </Link>
         ) : (
           <Typography
             onClick={list.onClick}

--- a/src/components/molecules/PlenumCard/PlenumCard.stories.tsx
+++ b/src/components/molecules/PlenumCard/PlenumCard.stories.tsx
@@ -8,6 +8,7 @@ export default meta
 
 export const Default: StoryObj<typeof PlenumCard> = {
   args: {
-    title: 'Break'
+    title: 'Break',
+    minutes: 10
   }
 }

--- a/src/components/molecules/PlenumCard/index.tsx
+++ b/src/components/molecules/PlenumCard/index.tsx
@@ -1,22 +1,27 @@
 import { Typography, Box } from '@mui/material'
+import { FC } from 'react'
 import { Colors } from 'src/styles/color'
 
-export interface PlenumCardProps {
+export type PlenumCardProps = {
   title: string
+  minutes: number
 }
 
-export const PlenumCard = ({ title }: PlenumCardProps) => {
+export const PlenumCard: FC<PlenumCardProps> = ({ title, minutes }) => {
   return (
     <Box
       sx={{
         backgroundColor: Colors.background.secondary_blue,
         padding: '20px 16px',
         borderRadius: '4px',
-        // TODO(@maito1201): タイムテーブルに組み込んだ時の適度な幅にする
-        width: '100vw'
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
       }}
     >
       <Typography variant="body2">{title}</Typography>
+      <Typography variant="caption">{`(${minutes}min)`}</Typography>
     </Box>
   )
 }

--- a/src/components/molecules/TimetableRoomHeader/TimetableRoomHeader.stories.tsx
+++ b/src/components/molecules/TimetableRoomHeader/TimetableRoomHeader.stories.tsx
@@ -1,0 +1,19 @@
+import { StoryObj, Meta } from '@storybook/react'
+import { TimetableRoomHeader } from '.'
+
+const meta: Meta<typeof TimetableRoomHeader> = {
+  component: TimetableRoomHeader
+}
+export default meta
+
+export const RoomA: StoryObj<typeof TimetableRoomHeader> = {
+  args: {
+    roomName: 'Room A'
+  }
+}
+
+export const RoomB: StoryObj<typeof TimetableRoomHeader> = {
+  args: {
+    roomName: 'Room B'
+  }
+}

--- a/src/components/molecules/TimetableRoomHeader/index.tsx
+++ b/src/components/molecules/TimetableRoomHeader/index.tsx
@@ -1,0 +1,70 @@
+import { Box, Typography } from '@mui/material'
+import { type FC } from 'react'
+import { Colors } from 'src/styles/color'
+// TODO: スポンサーイラストの掲載許可が取れたらコメントアウトを外す。
+// import Image from 'next/image'
+
+type Props = {
+  roomName: 'Room A' | 'Room B'
+}
+
+const getBackgroundColor = (roomName: Props['roomName']) => {
+  switch (roomName) {
+    case 'Room A':
+      return { backgroundColor: Colors.background.primary_pink }
+    case 'Room B':
+      return { backgroundColor: Colors.background.primary_green }
+    default:
+      throw new Error(`Invalid room: ${roomName}`)
+  }
+}
+
+// TODO: スポンサーイラストの掲載許可が取れたらコメントアウトを外す。
+// const getImage = (roomName: Props['roomName']) => {
+//   switch (roomName) {
+//     case 'Room A':
+//       return { src: '/rooms/gopher_room_a.png' }
+//     case 'Room B':
+//       return { src: '/rooms/gopher_room_b.png' }
+//     default:
+//       throw new Error(`Invalid room: ${roomName}`)
+//   }
+// }
+
+export const TimetableRoomHeader: FC<Props> = ({ roomName }) => {
+  const { backgroundColor } = getBackgroundColor(roomName)
+  // TODO: スポンサーイラストの掲載許可が取れたらコメントアウトを外す。
+  // const { src } = getImage(roomName)
+
+  return (
+    <Box sx={{ position: 'relative', backgroundColor: backgroundColor, borderRadius: '8px 8px 0 0' }}>
+      <Typography
+        variant="body2"
+        sx={{
+          textAlign: 'center',
+          color: Colors.text.white,
+          padding: '8px 16px',
+          margin: 0
+        }}
+      >
+        {roomName}
+      </Typography>
+      {/* TODO: スポンサーイラストの掲載許可が取れたらコメントアウトを外す。
+      <Image
+        src={src}
+        alt={`illustration of Gopher for ${roomName}`}
+        width={64}
+        height={64}
+        style={{
+          position: 'absolute',
+          right: '16px',
+          top: '0',
+          bottom: '0',
+          margin: 'auto 0',
+          border: `4px solid ${backgroundColor}`,
+          borderRadius: '50%'
+        }}
+      /> */}
+    </Box>
+  )
+}

--- a/src/components/molecules/TrackCard/TrackCard.stories.tsx
+++ b/src/components/molecules/TrackCard/TrackCard.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { faker } from '@faker-js/faker'
 import { TrackCard } from '.'
-import { Colors } from 'src/styles/color'
 
 const meta: Meta<typeof TrackCard> = {
   component: TrackCard
@@ -12,22 +11,22 @@ type Story = StoryObj<typeof TrackCard>
 
 export const Default: Story = {
   args: {
-    id: 'A1-1',
+    roomName: 'Room A',
+    sessionId: 'A0-L',
     title: faker.lorem.paragraph(),
-    minute: 20,
-    speaker: faker.name.fullName(),
-    speakerIcon: faker.image.avatar()
+    sessionType: 'Long Talk(40min)',
+    speakerName: faker.name.fullName(),
+    profilePicture: faker.image.avatar()
   }
 }
 
 export const Green: Story = {
   args: {
-    id: 'A1-1',
+    roomName: 'Room B',
+    sessionId: 'B0-S',
     title: faker.lorem.paragraph(),
-    minute: 20,
-    speaker: faker.name.fullName(),
-    speakerIcon: faker.image.avatar(),
-    color: Colors.background.secondary_green,
-    idColor: Colors.background.primary_green
+    sessionType: 'Short Talk(20min)',
+    speakerName: faker.name.fullName(),
+    profilePicture: faker.image.avatar()
   }
 }

--- a/src/components/molecules/TrackCard/index.tsx
+++ b/src/components/molecules/TrackCard/index.tsx
@@ -1,70 +1,102 @@
 import { Typography, Box } from '@mui/material'
 import { Colors } from 'src/styles/color'
-import Image, { StaticImageData } from 'next/image'
+import Image from 'next/image'
+import { FC } from 'react'
+import { SessionLabel } from 'src/components/atoms/SessionLabel'
+import Link from 'next/link'
 
-export interface TrackCardProps {
-  id: string
+export type TrackCardProps = {
+  roomName: 'Room A' | 'Room B'
+  sessionId: string
   title: string
-  minute: number
-  speaker: string
-  speakerIcon: string | StaticImageData
-  color?: string
-  idColor?: string
+  sessionType: string | null
+  speakerName: string
+  profilePicture: string
 }
 
-export const TrackCard = ({
-  id,
+const getBackgroundColor = (roomName: TrackCardProps['roomName']) => {
+  switch (roomName) {
+    case 'Room A':
+      return { backgroundColor: Colors.background.secondary_pink } as const
+    case 'Room B':
+      return { backgroundColor: Colors.background.secondary_green } as const
+    default:
+      throw new Error(`Invalid room ${roomName}`)
+  }
+}
+
+const getHeight = (sessionType: TrackCardProps['sessionType']) => {
+  const defaultHeight = { height: '140px' }
+  if (!sessionType) {
+    return defaultHeight
+  }
+  if (sessionType.includes('40min')) {
+    return { height: '280px' }
+  }
+  return defaultHeight
+}
+
+export const TrackCard: FC<TrackCardProps> = ({
+  roomName,
+  sessionId,
   title,
-  minute,
-  speaker,
-  speakerIcon,
-  color = Colors.background.secondary_pink,
-  idColor = Colors.background.primary_pink
-}: TrackCardProps) => {
+  sessionType,
+  speakerName,
+  profilePicture
+}) => {
+  const { backgroundColor } = getBackgroundColor(roomName)
+  const { height } = getHeight(sessionType)
+
   return (
-    <Box
-      sx={{
-        backgroundColor: color,
-        padding: '16px',
-        borderRadius: '4px',
-        width: '100%'
-      }}
-    >
+    <Link href={`/sessions/${sessionId}`}>
       <Box
         sx={{
+          backgroundColor: backgroundColor,
+          padding: '16px',
+          borderRadius: '4px',
+          width: '100%',
+          height: height,
           display: 'flex',
-          backgroundColor: idColor,
-          borderRadius: '2px',
-          width: 'fit-content',
-          padding: '0 4px',
-          mb: '4px'
+          flexDirection: 'column',
+          gap: '4px',
+          ':hover': {
+            opacity: '0.6'
+          }
         }}
       >
-        <Typography variant="caption" color={Colors.text.white}>
-          {id}
+        <SessionLabel sessionId={sessionId} roomName={roomName} isRoomNameDisplayed={false} />
+        <Typography
+          variant="body2"
+          sx={{
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: 2,
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+            flexGrow: 1
+          }}
+        >
+          {title}
         </Typography>
-      </Box>
-      <Box mb="4px">
-        <Typography variant="body2">{title}</Typography>
-      </Box>
-      <Box display="flex" alignItems="center">
-        <Box width="20px" height="20px" borderRadius="50%" overflow="hidden" margin="0 4px 0 0">
-          <Image
-            src={speakerIcon}
-            width={20}
-            height={20}
-            style={{ objectFit: 'contain' }}
-            alt={`${speaker}'s icon`}
-            quality={100}
-          />
+        <Box display="flex" alignItems="center">
+          <Box width="20px" height="20px" borderRadius="50%" overflow="hidden" margin="0 4px 0 0">
+            <Image
+              src={profilePicture}
+              width={20}
+              height={20}
+              style={{ objectFit: 'contain' }}
+              alt={`${speakerName}'s icon`}
+              quality={100}
+            />
+          </Box>
+          <Typography variant="caption" fontWeight="bold">
+            {speakerName}
+          </Typography>
+          <Typography variant="caption" margin="0 0 0 auto">
+            {sessionType}
+          </Typography>
         </Box>
-        <Typography variant="caption" fontWeight="bold">
-          {speaker}
-        </Typography>
-        <Typography variant="caption" margin="0 0 0 auto">
-          ({minute}min)
-        </Typography>
       </Box>
-    </Box>
+    </Link>
   )
 }

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -58,8 +58,7 @@ export const Header = () => {
     return [
       { href: '/', label: 'Home' },
       { href: '/sessions', label: 'Sessions' },
-      // TODO(taigakiyokawa): Revert to `/timetable` when the page has implemented.
-      { href: 'https://sessionize.com/api/v2/jmtn42ls/view/GridSmart', label: 'Timetable', openNewTab: true },
+      { href: '/timetable', label: 'Timetable' },
       { href: '/floor_guide', label: 'Floor Guide' },
       { href: '/staff', label: 'Staff' },
       {

--- a/src/pages/timetable.tsx
+++ b/src/pages/timetable.tsx
@@ -1,14 +1,186 @@
-import { GetStaticProps } from 'next'
-import { PageTop } from 'src/components/pages'
+import { Box, Typography } from '@mui/material'
+import dayjs from 'dayjs'
+import { GetStaticProps, NextPage } from 'next'
+import { Fragment } from 'react'
+import { Layout } from 'src/components/commons'
+import { PlenumCard, PlenumCardProps, TrackCard, TrackCardProps } from 'src/components/molecules'
+import { fetchSessionize } from 'src/modules/sessionize/fetch-sessionize'
+import { getSpeaker } from 'src/modules/sessionize/utils'
+import { getSessionType } from 'src/modules/sessionize/utils'
+import { getRoom, getSessionId } from 'src/modules/sessionize/utils'
+import { TimetableRoomHeader } from 'src/components/molecules/TimetableRoomHeader'
 
-const Index = () => {
-  /* TODO: 各ページの実装 */
-  return <PageTop />
+type PlenumSessionInfo = PlenumCardProps
+type RoomSessionInfo = TrackCardProps
+
+type TimetableSession = {
+  startsAt: string
+  plenum: PlenumSessionInfo | null
+  roomA: RoomSessionInfo | null
+  roomB: RoomSessionInfo | null
 }
 
-// NOTE: next exportで静的ファイルとして生成するため空のpropsを宣言する
-export const getStaticProps: GetStaticProps = async () => {
-  return { props: {} }
+type Props = {
+  timeTableSessions: TimetableSession[]
+}
+
+// Sessions not belong to any speakers, like opening, breaks, and closing.
+const plenumSessions: TimetableSession[] = [
+  { startsAt: '2023-06-02T10:00:00', plenum: { title: 'Opening', minutes: 10 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T10:50:00', plenum: { title: 'Break', minutes: 10 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T12:00:00', plenum: { title: 'Lunch break', minutes: 70 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T13:50:00', plenum: { title: 'Break', minutes: 10 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T15:00:00', plenum: { title: 'Break', minutes: 20 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T16:20:00', plenum: { title: 'Break', minutes: 10 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T17:30:00', plenum: { title: 'Break', minutes: 15 }, roomA: null, roomB: null },
+  { startsAt: '2023-06-02T18:25:00', plenum: { title: 'Closing', minutes: 20 }, roomA: null, roomB: null }
+]
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const { sessions, rooms, categories, speakers } = await fetchSessionize()
+
+  // Format all sessions for using timetable.
+  // Divide sessions between room A and B.
+  const roomSessions: TimetableSession[] = sessions.map(
+    ({ roomId, title, startsAt, speakers: speakerIds, categoryItems, questionAnswers }) => {
+      const { name: roomName } = getRoom(rooms, roomId)
+      const sessionId = getSessionId(questionAnswers)
+      const sessionType = getSessionType(categories, categoryItems)
+      const { fullName: speakerName, profilePicture } = getSpeaker(speakers, speakerIds[0])
+
+      const sessionInfo: RoomSessionInfo = {
+        roomName,
+        sessionId,
+        title,
+        sessionType,
+        speakerName,
+        profilePicture
+      }
+
+      switch (roomName) {
+        case 'Room A':
+          return {
+            startsAt,
+            plenum: null,
+            roomA: sessionInfo,
+            roomB: null
+          }
+        case 'Room B':
+          return {
+            startsAt,
+            plenum: null,
+            roomA: null,
+            roomB: sessionInfo
+          }
+        default:
+          throw new Error(`Invalid room: ${roomName}`)
+      }
+    }
+  )
+
+  // Combine room A's and B's sessions with the same startsAt.
+  // Add plenumSessions as initialValue of reduce().
+  const timeTableSessions: TimetableSession[] = roomSessions.reduce((accumulator, currentSession) => {
+    const { startsAt, roomA, roomB } = currentSession
+    const existingSession: TimetableSession | undefined = accumulator.find(s => s.startsAt === startsAt)
+
+    if (existingSession) {
+      if (roomA) {
+        existingSession.roomA = roomA
+      } else if (roomB) {
+        existingSession.roomB = roomB
+      }
+    } else {
+      accumulator.push(currentSession)
+    }
+
+    return accumulator
+  }, plenumSessions)
+
+  // Sort all sessions by comparing startsAt time in order of earliest to latest.
+  const sortedTimeTableSessions = timeTableSessions.sort((a, b) => {
+    if (dayjs(a.startsAt).isBefore(dayjs(b.startsAt))) {
+      return -1
+    } else if (dayjs(a.startsAt).isAfter(dayjs(b.startsAt))) {
+      return 1
+    }
+    return 0
+  })
+
+  console.log(sortedTimeTableSessions)
+
+  return { props: { timeTableSessions: sortedTimeTableSessions } }
+}
+
+const Index: NextPage<Props> = ({ timeTableSessions }) => {
+  return (
+    <Layout>
+      <Box>
+        <Typography variant="h2" sx={{ textAlign: 'center', paddingTop: { xs: '64px', sm: '128px' } }}>
+          2023.06.02(Fri)
+        </Typography>
+        <Box
+          sx={{
+            maxWidth: '1024px',
+            mx: 'auto',
+            px: '16px',
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr 1fr',
+            rowGap: '4px',
+            columnGap: { xs: '8px', sm: '24px' },
+            alignItems: 'start'
+          }}
+        >
+          {/* Stick table header to half height of header when scrolled, z-index is header's + 100. */}
+          <Box sx={{ gridColumn: '2 / 3', position: 'sticky', top: '64px', zIndex: 1200 }}>
+            <TimetableRoomHeader roomName="Room A" />
+          </Box>
+          {/* Stick table header to half height of header when scrolled, z-index is header's + 100. */}
+          <Box sx={{ gridColumn: '3 / 4', position: 'sticky', top: '64px', zIndex: 1200 }}>
+            <TimetableRoomHeader roomName="Room B" />
+          </Box>
+          {timeTableSessions.map(({ startsAt, plenum, roomA, roomB }) => {
+            return (
+              <Fragment key={startsAt}>
+                <Box sx={{ gridColumn: '1 / 2' }}>
+                  <Typography sx={{ textAlign: 'right' }}>{dayjs(startsAt).format('HH:mm')}</Typography>
+                </Box>
+                {plenum && (
+                  <Box sx={{ gridColumn: '2 / 4' }}>
+                    <PlenumCard title={plenum.title} minutes={plenum.minutes} />
+                  </Box>
+                )}
+                {roomA && (
+                  <Box sx={{ gridColumn: '2 / 3' }}>
+                    <TrackCard
+                      roomName={roomA.roomName}
+                      sessionId={roomA.sessionId}
+                      title={roomA.title}
+                      sessionType={roomA.sessionType}
+                      speakerName={roomA.speakerName}
+                      profilePicture={roomA.profilePicture}
+                    />
+                  </Box>
+                )}
+                {roomB && (
+                  <Box sx={{ gridColumn: '3 / 4' }}>
+                    <TrackCard
+                      roomName={roomB.roomName}
+                      sessionId={roomB.sessionId}
+                      title={roomB.title}
+                      sessionType={roomB.sessionType}
+                      speakerName={roomB.speakerName}
+                      profilePicture={roomB.profilePicture}
+                    />
+                  </Box>
+                )}
+              </Fragment>
+            )
+          })}
+        </Box>
+      </Box>
+    </Layout>
+  )
 }
 
 export default Index


### PR DESCRIPTION
## 概要

`/timetable` ページを getStaticProps を使って実装しました。関連コンポーネント (TrackCard, PlenumCard) の調整も行っています。スタイルは可能な限りデザインに合わせましたが忠実ではないです。また、モバイル用の調整は本PRでは行っていません。 (モバイル幅になった時のデザインがないのでなんとなく片方のルームだけ表示されて A/B 切り替えボタンみたいなのを置いて切り替えるみたいなイメージをしています。できるかどうかは分からない。もっと良さげなアイディアありましたら教えてください。)


## やったこと

- TrackCard の調整 (スタイルの調整、 props の修正、各セッション詳細ページへのリンク追加)
- PlenumCard の調整 (幅の調整、 minutes prop の追加)
- TimetableRoomHeader の追加 (タイムテーブル上部の Room A/B のヘッダー、スポンサーの許諾が得られ次第イラストアイコンを追加する予定)
- ヘッダーのリンク変更
- `/pages/timetable.tsx` の実装

## スクリーンショット

<details><summary>PC</summary>

![Screenshot 2023-05-28 at 19 30 36](https://github.com/GoCon/2023/assets/40013676/68742db6-c959-4f49-9b25-db7ce9f67307)

![Screenshot 2023-05-28 at 19 31 01](https://github.com/GoCon/2023/assets/40013676/8dc1eb4d-f890-422e-ad36-622e869f6104)

![Screenshot 2023-05-28 at 19 31 29](https://github.com/GoCon/2023/assets/40013676/2fa444e4-4213-4c3b-bca7-52110917c57d)

![Screenshot 2023-05-28 at 19 31 45](https://github.com/GoCon/2023/assets/40013676/1e8389ed-1392-40c2-af5c-45ea3499c2ab)

</details>
