### PR TITLE
feat: Set meta page title in the pages routed dynamically

### DIFF
--- a/src/components/pages/PageSponsor/index.tsx
+++ b/src/components/pages/PageSponsor/index.tsx
@@ -4,12 +4,16 @@ import { Layout } from 'src/components/commons'
 import { type SponsorInfo } from 'src/modules/sponsors'
 import Grid from '@mui/material/Unstable_Grid2'
 import { FC } from 'react'
+import Head from 'next/head'
 
 type Props = Omit<SponsorInfo, 'id'>
 
 export const PageSponsor: FC<Props> = ({ name, logo, description }) => {
   return (
     <Layout>
+      <Head>
+        <title>{`${name} | Go Conference 2023`}</title>
+      </Head>
       <Grid container spacing={4} sx={{ maxWidth: '1024px', m: '128px auto 0', px: '16px' }}>
         <Grid xs={12} md={4} sx={{ position: 'relative', aspectRatio: '16/9' }}>
           <Image src={logo} fill alt={name} style={{ objectFit: 'contain' }} />

--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -20,6 +20,7 @@ import {
   getSpeaker,
   getTwitterUserName
 } from 'src/modules/sessionize/utils'
+import Head from 'next/head'
 
 type Props = {
   title: string
@@ -132,6 +133,9 @@ const Page: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   const { t } = useTranslation()
   return (
     <Layout>
+      <Head>
+        <title>{`${title} | Go Conference 2023`}</title>
+      </Head>
       <Box
         sx={{
           my: '128px',


### PR DESCRIPTION
これは https://github.com/GoCon/2023/pull/269 へ向けたPRです。

/sponsors/[plan]/[id] と /sessions/[id] のページタイトルが期待通り反映されるように各ページ内で Meta を呼び出すようにしました。

![image](https://github.com/GoCon/2023/assets/40013676/19b459f5-8b05-4dda-b255-dc1bf6281450)

![image](https://github.com/GoCon/2023/assets/40013676/f3882b55-3189-40e3-bb65-1baaf5e4618c)

