### PR TITLE
fix: Format speaker's name to the correct to display

### DIFF
--- a/src/modules/sessionize/utils.ts
+++ b/src/modules/sessionize/utils.ts
@@ -140,3 +140,22 @@ export const getTwitterUserName = (links: SessionizeSpeakerSchemaType['links']):
 
   return userName
 }
+
+/**
+ * Formats speaker's name to the correct to display.
+ * If the name is Japanese, return the name in order of last name to first name.
+ * If the last name is 'N/A' like the handle name, return only the first name.
+ * @param firstName - speaker.firstName from Sessionize API.
+ * @param lastName  - speaker.lastName from Sessionize API.
+ */
+export const formatSpeakerName = (firstName: string, lastName: string): string => {
+  const japaneseUnicodeProperty = /^[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]*$/u
+  const isJapanese: boolean = japaneseUnicodeProperty.test(lastName)
+  if (isJapanese) {
+    return `${lastName} ${firstName}`
+  }
+  if (lastName === 'N/A') {
+    return `${firstName}`
+  }
+  return `${firstName} ${lastName}`
+}

--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -12,6 +12,7 @@ import NextLink from 'next/link'
 import { replaceUrlWithLink } from 'src/modules/util/text'
 import { fetchSessionize } from 'src/modules/sessionize/fetch-sessionize'
 import {
+  formatSpeakerName,
   getGoogleCalendarEventCreationLink,
   getRoom,
   getSession,
@@ -103,7 +104,8 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
   const sessionLevel = getSessionLevel(categories, categoryItems)
   const sessionType = getSessionType(categories, categoryItems)
   const googleCalendarEventCreationLink = getGoogleCalendarEventCreationLink(startsAt, endsAt, title, description)
-  const { fullName, profilePicture, bio, tagLine, links } = getSpeaker(speakers, speakerIds[0])
+  const { firstName, lastName, profilePicture, bio, tagLine, links } = getSpeaker(speakers, speakerIds[0])
+  const fullName = formatSpeakerName(firstName, lastName)
   const twitterUserName = getTwitterUserName(links)
 
   return {

--- a/src/pages/sessions/index.tsx
+++ b/src/pages/sessions/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps, NextPage } from 'next'
 import { fetchSessionize } from 'src/modules/sessionize/fetch-sessionize'
-import { getRoom, getSessionId, getSessionLevel, getSpeaker } from 'src/modules/sessionize/utils'
+import { formatSpeakerName, getRoom, getSessionId, getSessionLevel, getSpeaker } from 'src/modules/sessionize/utils'
 import { Box, Grid, Typography } from '@mui/material'
 import { Layout } from 'src/components/commons'
 import { SessionCard } from 'src/components/molecules'
@@ -18,7 +18,8 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
     ({ id, title, description, roomId, speakers: speakerIds, questionAnswers, categoryItems }) => {
       const { name: roomName } = getRoom(rooms, roomId)
       const sessionId = getSessionId(questionAnswers)
-      const { fullName, tagLine, profilePicture } = getSpeaker(speakers, speakerIds[0])
+      const { firstName, lastName, tagLine, profilePicture } = getSpeaker(speakers, speakerIds[0])
+      const fullName = formatSpeakerName(firstName, lastName)
       const sessionLevel = getSessionLevel(categories, categoryItems)
       const sessionType = getSessionLevel(categories, categoryItems)
 

--- a/src/pages/timetable.tsx
+++ b/src/pages/timetable.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react'
 import { Layout } from 'src/components/commons'
 import { PlenumCard, PlenumCardProps, TrackCard, TrackCardProps } from 'src/components/molecules'
 import { fetchSessionize } from 'src/modules/sessionize/fetch-sessionize'
-import { getSpeaker } from 'src/modules/sessionize/utils'
+import { formatSpeakerName, getSpeaker } from 'src/modules/sessionize/utils'
 import { getSessionType } from 'src/modules/sessionize/utils'
 import { getRoom, getSessionId } from 'src/modules/sessionize/utils'
 import { TimetableRoomHeader } from 'src/components/molecules/TimetableRoomHeader'
@@ -46,7 +46,8 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
       const { name: roomName } = getRoom(rooms, roomId)
       const sessionId = getSessionId(questionAnswers)
       const sessionType = getSessionType(categories, categoryItems)
-      const { fullName: speakerName, profilePicture } = getSpeaker(speakers, speakerIds[0])
+      const { firstName, lastName, profilePicture } = getSpeaker(speakers, speakerIds[0])
+      const speakerName = formatSpeakerName(firstName, lastName)
 
       const sessionInfo: RoomSessionInfo = {
         roomName,

--- a/src/pages/timetable.tsx
+++ b/src/pages/timetable.tsx
@@ -108,8 +108,6 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
     return 0
   })
 
-  console.log(sortedTimeTableSessions)
-
   return { props: { timeTableSessions: sortedTimeTableSessions } }
 }
 


### PR DESCRIPTION
以下の処理を行いスピーカーの名前をフォーマットする関数を追加し、期待通りに表示されるように各所を修正しました。
- スピーカーの名前が日本語の時に、姓 (lastName) → 名 (firstName) になるように変換する
- lastName が `N/A` の場合、 firstName のみを返す

日本語か否かの判定には、Unicode プロパティというものを使用して、与えられた文字列がひらがな、カタカナ、漢字を含む文字列か否かを判定しています。
- [Unicode プロパティエスケープ - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape)