### PR TITLE
feat: Add yagipy info

### DIFF
--- a/src/modules/staff/index.ts
+++ b/src/modules/staff/index.ts
@@ -132,5 +132,12 @@ export const staff: StaffInfo[] = [
     twitterLink: 'https://twitter.com/tenntenn',
     githubLink: 'https://github.com/tenntenn',
     otherLink: 'https://tenntenn.dev'
+  },
+  {
+    name: 'yagipy',
+    icon: 'https://avatars.githubusercontent.com/u/34264859?v=4',
+    twitterLink: 'https://twitter.com/yagipy_',
+    githubLink: 'https://github.com/yagipy',
+    otherLink: 'https://blog.yagipy.me'
   }
 ]


### PR DESCRIPTION
yagipy の情報を `/staff` に追加しました。

回答が遅くなってしまったので自分で出しました。
問題なければマージをお願いします。

## スクリーンショット
### PC
<img width="1084" alt="image" src="https://github.com/GoCon/2023/assets/34264859/59eb6bd5-da25-4c3e-b655-dfb7e3b30555">

### Mobile
<img width="392" alt="image" src="https://github.com/GoCon/2023/assets/34264859/705fbe01-a05a-4038-988b-93ec76759242">

