### PR TITLE
fix: Set og:title tag

### DIFF
--- a/src/components/commons/Layout/index.tsx
+++ b/src/components/commons/Layout/index.tsx
@@ -58,7 +58,7 @@ export const Layout: NextPage<LayoutProps> = ({ children }) => {
         <link rel="icon" href={config.basePath + '/favicon.ico'} />
         <meta name="description" content="Go Conference is a conference for Go programming language users." />
         <meta property="og:site_name" content="Go Conference 2023" />
-        <meta property="og:title" content="Go Conference 2023" />
+        <meta property="og:title" content={`${pageTitle} | Go Conference 2023`} key="title" />
         <meta property="og:description" content="Go Conference is a conference for Go programming language users." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://gocon.jp/2023" />

--- a/src/components/pages/PageSponsor/index.tsx
+++ b/src/components/pages/PageSponsor/index.tsx
@@ -13,6 +13,7 @@ export const PageSponsor: FC<Props> = ({ name, logo, description }) => {
     <Layout>
       <Head>
         <title>{`${name} | Go Conference 2023`}</title>
+        <meta property="og:title" content={`${name} | Go Conference 2023`} key="title" />
       </Head>
       <Grid container spacing={4} sx={{ maxWidth: '1024px', m: '128px auto 0', px: '16px' }}>
         <Grid xs={12} md={4} sx={{ position: 'relative', aspectRatio: '16/9' }}>

--- a/src/pages/sessions/[id].tsx
+++ b/src/pages/sessions/[id].tsx
@@ -138,6 +138,7 @@ const Page: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
     <Layout>
       <Head>
         <title>{`${title} | Go Conference 2023`}</title>
+        <meta property="og:title" content={`${title} | Go Conference 2023`} key="title" />
       </Head>
       <Box
         sx={{


### PR DESCRIPTION
## やったこと

- `<meta property="og:title" />` にタイトルを設定しました
    - SNS でシェアしたときに、セッション名やスポンサー名が表示されることを期待して設定しています
    - 基本的に `<title>` 要素と同じ内容を出すようにしています
    - 参考: https://nextjs.org/docs/pages/api-reference/components/head
## HTML の結果

(スポンサーページ)

```html
<meta property="og:title" content="株式会社カンム | Go Conference 2023">
```

(セッションページ)

```html
<meta property="og:title" content="タクシーアプリ『GO』高速マッチングシステムで実践したGoチューニングテクニック | Go Conference 2023">
```
